### PR TITLE
Fusaka updates prototype

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,9 +107,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy-chains"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19a9cc9d81ace3da457883b0bdf76776e55f1b84219a9e9d55c27ad308548d3f"
+checksum = "5674914c2cfdb866c21cb0c09d82374ee39a1395cf512e7515f4c014083b3fff"
 dependencies = [
  "alloy-primitives 1.2.1",
  "alloy-rlp",
@@ -144,8 +144,7 @@ dependencies = [
 [[package]]
 name = "alloy-consensus"
 version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c6ad411efe0f49e0e99b9c7d8749a1eb55f6dbf74a1bc6953ab285b02c4f67"
+source = "git+https://github.com/bharath-123/alloy?branch=fusaka%2Fdevnet2#9327426d15283ee2dae1ddf36bd2f5e6691d2e28"
 dependencies = [
  "alloy-eips 1.0.17",
  "alloy-primitives 1.2.1",
@@ -184,8 +183,7 @@ dependencies = [
 [[package]]
 name = "alloy-consensus-any"
 version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf397edad57b696501702d5887e4e14d7d0bbae9fbb6439e148d361f7254f45"
+source = "git+https://github.com/bharath-123/alloy?branch=fusaka%2Fdevnet2#9327426d15283ee2dae1ddf36bd2f5e6691d2e28"
 dependencies = [
  "alloy-consensus 1.0.17",
  "alloy-eips 1.0.17",
@@ -316,8 +314,7 @@ dependencies = [
 [[package]]
 name = "alloy-eips"
 version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "749b8449e4daf7359bdf1dabdba6ce424ff8b1bdc23bdb795661b2e991a08d87"
+source = "git+https://github.com/bharath-123/alloy?branch=fusaka%2Fdevnet2#9327426d15283ee2dae1ddf36bd2f5e6691d2e28"
 dependencies = [
  "alloy-eip2124 0.2.0",
  "alloy-eip2930 0.2.1",
@@ -358,8 +355,7 @@ dependencies = [
 [[package]]
 name = "alloy-genesis"
 version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fcbae2107f3f2df2b02bb7d9e81e8aa730ae371ca9dd7fd0c81c3d0cb78a452"
+source = "git+https://github.com/bharath-123/alloy?branch=fusaka%2Fdevnet2#9327426d15283ee2dae1ddf36bd2f5e6691d2e28"
 dependencies = [
  "alloy-eips 1.0.17",
  "alloy-primitives 1.2.1",
@@ -371,9 +367,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-hardforks"
-version = "0.2.7"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "977d2492ce210e34baf7b36afaacea272c96fbe6774c47e23f97d14033c0e94f"
+checksum = "819a3620fe125e0fff365363315ee5e24c23169173b19747dfd6deba33db8990"
 dependencies = [
  "alloy-chains",
  "alloy-eip2124 0.2.0",
@@ -424,8 +420,7 @@ dependencies = [
 [[package]]
 name = "alloy-json-rpc"
 version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc30b0e20fcd0843834ecad2a716661c7b9d5aca2486f8e96b93d5246eb83e06"
+source = "git+https://github.com/bharath-123/alloy?branch=fusaka%2Fdevnet2#9327426d15283ee2dae1ddf36bd2f5e6691d2e28"
 dependencies = [
  "alloy-primitives 1.2.1",
  "alloy-sol-types 1.2.1",
@@ -439,8 +434,7 @@ dependencies = [
 [[package]]
 name = "alloy-network"
 version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaeb681024cf71f5ca14f3d812c0a8d8b49f13f7124713538e66d74d3bfe6aff"
+source = "git+https://github.com/bharath-123/alloy?branch=fusaka%2Fdevnet2#9327426d15283ee2dae1ddf36bd2f5e6691d2e28"
 dependencies = [
  "alloy-consensus 1.0.17",
  "alloy-consensus-any 1.0.17",
@@ -478,8 +472,7 @@ dependencies = [
 [[package]]
 name = "alloy-network-primitives"
 version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a03ad273e1c55cc481889b4130e82860e33624e6969e9a08854e0f3ebe659295"
+source = "git+https://github.com/bharath-123/alloy?branch=fusaka%2Fdevnet2#9327426d15283ee2dae1ddf36bd2f5e6691d2e28"
 dependencies = [
  "alloy-consensus 1.0.17",
  "alloy-eips 1.0.17",
@@ -490,9 +483,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-node-bindings"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d4f3ab81744547ab8283aa94c9670d3880ac826642e52739e3c4ecbfa84857a"
+checksum = "0d17165a7f049283bcc047720cb97e152f188dc1b5a40f9d50fbee1a0dfb4e21"
 dependencies = [
  "alloy-genesis",
  "alloy-hardforks",
@@ -544,7 +537,7 @@ dependencies = [
  "derive_more 2.0.1",
  "foldhash",
  "hashbrown 0.15.4",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "itoa",
  "k256 0.13.4",
  "keccak-asm",
@@ -574,7 +567,7 @@ dependencies = [
  "foldhash",
  "getrandom 0.3.3",
  "hashbrown 0.15.4",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "itoa",
  "k256 0.13.4",
  "keccak-asm",
@@ -592,8 +585,7 @@ dependencies = [
 [[package]]
 name = "alloy-provider"
 version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abc164acf8c41c756e76c7aea3be8f0fb03f8a3ef90a33e3ddcea5d1614d8779"
+source = "git+https://github.com/bharath-123/alloy?branch=fusaka%2Fdevnet2#9327426d15283ee2dae1ddf36bd2f5e6691d2e28"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 1.0.17",
@@ -622,7 +614,7 @@ dependencies = [
  "lru 0.13.0",
  "parking_lot",
  "pin-project",
- "reqwest 0.12.20",
+ "reqwest 0.12.22",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -635,8 +627,7 @@ dependencies = [
 [[package]]
 name = "alloy-pubsub"
 version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670d155c3e35bcaa252ca706a2757a456c56aa71b80ad1539d07d49b86304e78"
+source = "git+https://github.com/bharath-123/alloy?branch=fusaka%2Fdevnet2#9327426d15283ee2dae1ddf36bd2f5e6691d2e28"
 dependencies = [
  "alloy-json-rpc 1.0.17",
  "alloy-primitives 1.2.1",
@@ -672,14 +663,13 @@ checksum = "64b728d511962dda67c1bc7ea7c03736ec275ed2cf4c35d9585298ac9ccf3b73"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "alloy-rpc-client"
 version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c44d31bcb9afad460915fe1fba004a2af5a07a3376c307b9bdfeec3678c209"
+source = "git+https://github.com/bharath-123/alloy?branch=fusaka%2Fdevnet2#9327426d15283ee2dae1ddf36bd2f5e6691d2e28"
 dependencies = [
  "alloy-json-rpc 1.0.17",
  "alloy-primitives 1.2.1",
@@ -691,7 +681,7 @@ dependencies = [
  "async-stream",
  "futures",
  "pin-project",
- "reqwest 0.12.20",
+ "reqwest 0.12.22",
  "serde",
  "serde_json",
  "tokio",
@@ -706,8 +696,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types"
 version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ba2cf3d3c6ece87f1c6bb88324a997f28cf0ad7e98d5e0b6fa91c4003c30916"
+source = "git+https://github.com/bharath-123/alloy?branch=fusaka%2Fdevnet2#9327426d15283ee2dae1ddf36bd2f5e6691d2e28"
 dependencies = [
  "alloy-primitives 1.2.1",
  "alloy-rpc-types-engine",
@@ -719,8 +708,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-admin"
 version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4ce874dde17cc749f1aa8883e0c1431ddda6ba6dd9c9eb9b31d1fb0a6023830"
+source = "git+https://github.com/bharath-123/alloy?branch=fusaka%2Fdevnet2#9327426d15283ee2dae1ddf36bd2f5e6691d2e28"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives 1.2.1",
@@ -731,8 +719,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-anvil"
 version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e80e2ffa56956a92af375df1422b239fde6552bd222dfeaeb39f07949060fa"
+source = "git+https://github.com/bharath-123/alloy?branch=fusaka%2Fdevnet2#9327426d15283ee2dae1ddf36bd2f5e6691d2e28"
 dependencies = [
  "alloy-primitives 1.2.1",
  "alloy-rpc-types-eth 1.0.17",
@@ -743,8 +730,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-any"
 version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef5b22062142ce3b2ed3374337d4b343437e5de6959397f55d2c9fe2c2ce0162"
+source = "git+https://github.com/bharath-123/alloy?branch=fusaka%2Fdevnet2#9327426d15283ee2dae1ddf36bd2f5e6691d2e28"
 dependencies = [
  "alloy-consensus-any 1.0.17",
  "alloy-rpc-types-eth 1.0.17",
@@ -754,8 +740,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-beacon"
 version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "438a7a3a5c5d11877787e324dd1ffd9ab82314ca145513ebe8d12257cbfefb5b"
+source = "git+https://github.com/bharath-123/alloy?branch=fusaka%2Fdevnet2#9327426d15283ee2dae1ddf36bd2f5e6691d2e28"
 dependencies = [
  "alloy-eips 1.0.17",
  "alloy-primitives 1.2.1",
@@ -772,8 +757,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-debug"
 version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f53a2a78b44582e0742ab96d5782842d9b90cebf6ef6ccd8be864ae246fdd0f"
+source = "git+https://github.com/bharath-123/alloy?branch=fusaka%2Fdevnet2#9327426d15283ee2dae1ddf36bd2f5e6691d2e28"
 dependencies = [
  "alloy-primitives 1.2.1",
  "serde",
@@ -782,8 +766,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-engine"
 version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7041c3fd4dcd7af95e86280944cc33b4492ac2ddbe02f84079f8019742ec2857"
+source = "git+https://github.com/bharath-123/alloy?branch=fusaka%2Fdevnet2#9327426d15283ee2dae1ddf36bd2f5e6691d2e28"
 dependencies = [
  "alloy-consensus 1.0.17",
  "alloy-eips 1.0.17",
@@ -822,8 +805,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-eth"
 version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391e59f81bacbffc7bddd2da3a26d6eec0e2058e9237c279e9b1052bdf21b49e"
+source = "git+https://github.com/bharath-123/alloy?branch=fusaka%2Fdevnet2#9327426d15283ee2dae1ddf36bd2f5e6691d2e28"
 dependencies = [
  "alloy-consensus 1.0.17",
  "alloy-consensus-any 1.0.17",
@@ -843,8 +825,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-mev"
 version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3f327d4cd140eca2c6c27c82c381aba6fa6a32cbb697c146b5607532f82167"
+source = "git+https://github.com/bharath-123/alloy?branch=fusaka%2Fdevnet2#9327426d15283ee2dae1ddf36bd2f5e6691d2e28"
 dependencies = [
  "alloy-consensus 1.0.17",
  "alloy-eips 1.0.17",
@@ -858,8 +839,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-trace"
 version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29d96238f37e8a72dcf2cf6bead4c4f91dec1c0720b12be10558406e1633a804"
+source = "git+https://github.com/bharath-123/alloy?branch=fusaka%2Fdevnet2#9327426d15283ee2dae1ddf36bd2f5e6691d2e28"
 dependencies = [
  "alloy-primitives 1.2.1",
  "alloy-rpc-types-eth 1.0.17",
@@ -872,8 +852,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-txpool"
 version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e45d00db47a280d0a6e498b6e63344bccd9485d8860d2e2f06b680200c37ebc2"
+source = "git+https://github.com/bharath-123/alloy?branch=fusaka%2Fdevnet2#9327426d15283ee2dae1ddf36bd2f5e6691d2e28"
 dependencies = [
  "alloy-primitives 1.2.1",
  "alloy-rpc-types-eth 1.0.17",
@@ -895,8 +874,7 @@ dependencies = [
 [[package]]
 name = "alloy-serde"
 version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea08bc854235d4dff08fd57df8033285c11b8d7548b20c6da218194e7e6035f"
+source = "git+https://github.com/bharath-123/alloy?branch=fusaka%2Fdevnet2#9327426d15283ee2dae1ddf36bd2f5e6691d2e28"
 dependencies = [
  "alloy-primitives 1.2.1",
  "arbitrary",
@@ -907,8 +885,7 @@ dependencies = [
 [[package]]
 name = "alloy-signer"
 version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcb3759f85ef5f010a874d9ebd5ee6ce01cac65211510863124e0ebac6552db0"
+source = "git+https://github.com/bharath-123/alloy?branch=fusaka%2Fdevnet2#9327426d15283ee2dae1ddf36bd2f5e6691d2e28"
 dependencies = [
  "alloy-primitives 1.2.1",
  "async-trait",
@@ -922,8 +899,7 @@ dependencies = [
 [[package]]
 name = "alloy-signer-local"
 version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14d95902d29e1290809e1c967a1e974145b44b78f6e3e12fc07a60c1225e3df0"
+source = "git+https://github.com/bharath-123/alloy?branch=fusaka%2Fdevnet2#9327426d15283ee2dae1ddf36bd2f5e6691d2e28"
 dependencies = [
  "alloy-consensus 1.0.17",
  "alloy-network",
@@ -946,7 +922,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -960,7 +936,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -972,11 +948,11 @@ dependencies = [
  "alloy-sol-macro-input 0.8.25",
  "const-hex",
  "heck 0.5.0",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "proc-macro-error2",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
  "syn-solidity 0.8.25",
  "tiny-keccak",
 ]
@@ -990,11 +966,11 @@ dependencies = [
  "alloy-sol-macro-input 1.2.1",
  "const-hex",
  "heck 0.5.0",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "proc-macro-error2",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
  "syn-solidity 1.2.1",
  "tiny-keccak",
 ]
@@ -1011,7 +987,7 @@ dependencies = [
  "macro-string",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
  "syn-solidity 0.8.25",
 ]
 
@@ -1027,7 +1003,7 @@ dependencies = [
  "macro-string",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
  "syn-solidity 1.2.1",
 ]
 
@@ -1079,8 +1055,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport"
 version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcdf4b7fc58ebb2605b2fc5a33dae5cf15527ea70476978351cc0db1c596ea93"
+source = "git+https://github.com/bharath-123/alloy?branch=fusaka%2Fdevnet2#9327426d15283ee2dae1ddf36bd2f5e6691d2e28"
 dependencies = [
  "alloy-json-rpc 1.0.17",
  "alloy-primitives 1.2.1",
@@ -1102,12 +1077,11 @@ dependencies = [
 [[package]]
 name = "alloy-transport-http"
 version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c4b0f3a9c28bcd3761504d9eb3578838d6d115c8959fc1ea05f59a3a8f691af"
+source = "git+https://github.com/bharath-123/alloy?branch=fusaka%2Fdevnet2#9327426d15283ee2dae1ddf36bd2f5e6691d2e28"
 dependencies = [
  "alloy-json-rpc 1.0.17",
  "alloy-transport",
- "reqwest 0.12.20",
+ "reqwest 0.12.22",
  "serde_json",
  "tower 0.5.2",
  "tracing",
@@ -1117,8 +1091,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-ipc"
 version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758edb7c266374374e001c50fb1ea89cb5ed48d47ffbf297599f2a557804dd3b"
+source = "git+https://github.com/bharath-123/alloy?branch=fusaka%2Fdevnet2#9327426d15283ee2dae1ddf36bd2f5e6691d2e28"
 dependencies = [
  "alloy-json-rpc 1.0.17",
  "alloy-pubsub",
@@ -1137,8 +1110,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-ws"
 version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5596b913d1299ee37a9c1bb5118b2639bf253dc1088957bdf2073ae63a6fdfa"
+source = "git+https://github.com/bharath-123/alloy?branch=fusaka%2Fdevnet2#9327426d15283ee2dae1ddf36bd2f5e6691d2e28"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -1180,7 +1152,7 @@ dependencies = [
  "arrayvec",
  "derive_arbitrary",
  "derive_more 2.0.1",
- "nybbles 0.4.0",
+ "nybbles 0.4.1",
  "proptest",
  "proptest-derive",
  "serde",
@@ -1191,14 +1163,13 @@ dependencies = [
 [[package]]
 name = "alloy-tx-macros"
 version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79bf2869e66904b2148c809e7a75e23ca26f5d7b46663a149a1444fb98a69d1d"
+source = "git+https://github.com/bharath-123/alloy?branch=fusaka%2Fdevnet2#9327426d15283ee2dae1ddf36bd2f5e6691d2e28"
 dependencies = [
  "alloy-primitives 1.2.1",
  "darling 0.20.11",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1289,7 +1260,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1440,7 +1411,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
 dependencies = [
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1478,7 +1449,7 @@ dependencies = [
  "num-traits",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1567,7 +1538,7 @@ checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1754,7 +1725,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1765,7 +1736,7 @@ checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1823,7 +1794,7 @@ checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2037,7 +2008,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2176,7 +2147,7 @@ dependencies = [
  "boa_interner",
  "boa_macros",
  "boa_string",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "num-bigint",
  "rustc-hash 2.1.1",
 ]
@@ -2202,7 +2173,7 @@ dependencies = [
  "fast-float2",
  "hashbrown 0.15.4",
  "icu_normalizer 1.5.0",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "intrusive-collections",
  "itertools 0.13.0",
  "num-bigint",
@@ -2248,7 +2219,7 @@ dependencies = [
  "boa_gc",
  "boa_macros",
  "hashbrown 0.15.4",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "once_cell",
  "phf 0.11.3",
  "rustc-hash 2.1.1",
@@ -2263,7 +2234,7 @@ checksum = "9fd3f870829131332587f607a7ff909f1af5fc523fd1b192db55fbbdf52e8d3c"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
  "synstructure 0.13.2",
 ]
 
@@ -2395,9 +2366,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.18.1"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "byte-slice-cast"
@@ -2428,7 +2399,7 @@ checksum = "7ecc273b49b3205b83d648f0690daa588925572cc5063745bfe547fe7ec8e1a1"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2724,7 +2695,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3171,9 +3142,9 @@ dependencies = [
 
 [[package]]
 name = "crunchy"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
@@ -3230,7 +3201,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3261,7 +3232,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3297,7 +3268,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3345,7 +3316,7 @@ dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
  "strsim 0.11.1",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3367,7 +3338,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3421,7 +3392,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3491,7 +3462,7 @@ checksum = "510c292c8cf384b1a340b816a9a6cf2599eb8f566a44949024af88418000c50b"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3502,7 +3473,7 @@ checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3523,7 +3494,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3533,7 +3504,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3546,7 +3517,7 @@ dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
  "rustc_version 0.4.1",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3575,7 +3546,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3587,7 +3558,7 @@ dependencies = [
  "convert_case 0.7.1",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
  "unicode-xid 0.2.6",
 ]
 
@@ -3722,7 +3693,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3831,7 +3802,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3979,7 +3950,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3999,7 +3970,7 @@ checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4011,7 +3982,7 @@ dependencies = [
  "once_cell",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4274,7 +4245,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4343,7 +4314,7 @@ dependencies = [
  "reqwest 0.11.27",
  "serde",
  "serde_json",
- "syn 2.0.103",
+ "syn 2.0.104",
  "toml 0.8.23",
  "walkdir",
 ]
@@ -4361,7 +4332,7 @@ dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
  "serde_json",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4387,7 +4358,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum 0.26.3",
- "syn 2.0.103",
+ "syn 2.0.104",
  "tempfile",
  "thiserror 1.0.69",
  "tiny-keccak",
@@ -4913,7 +4884,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5245,7 +5216,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -5254,9 +5225,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
+checksum = "17da50a276f1e01e0ba6c029e47b7100754904ee8a278f886546e98575380785"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -5264,7 +5235,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.3.1",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -5684,7 +5655,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.10",
+ "h2 0.4.11",
  "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
@@ -5762,9 +5733,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc2fdfdbff08affe55bb779f33b053aa1fe5dd5b54c257343c17edfa55711bdb"
+checksum = "7f66d5bd4c6f02bf0542fad85d626775bab9258cf795a4256dcaf3161114d1df"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -6011,7 +5982,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -6086,7 +6057,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -6127,9 +6098,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "arbitrary",
  "equivalent",
@@ -6202,7 +6173,7 @@ dependencies = [
  "indoc",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -6251,6 +6222,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "189d0897e4cbe8c75efedf3502c18c887b05046e59d28404d4d8e46cbc4d1e86"
 dependencies = [
  "memoffset",
+]
+
+[[package]]
+name = "io-uring"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -6586,7 +6568,7 @@ dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -6930,9 +6912,9 @@ checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.18.1+1.9.0"
+version = "0.18.2+1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1dcb20f84ffcdd825c7a311ae347cce604a6f084a767dec4a4929829645290e"
+checksum = "1c42fe03df2bd3c53a3a9c7317ad91d80c81cd1fb0caec8d7cc4cd2bfa10c222"
 dependencies = [
  "cc",
  "libc",
@@ -6958,9 +6940,9 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libp2p-identity"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbb68ea10844211a59ce46230909fd0ea040e8a192454d4cc2ee0d53e12280eb"
+checksum = "3104e13b51e4711ff5738caa1fb54467c8604c2e94d607e27745bcf709068774"
 dependencies = [
  "asn1_der",
  "bs58 0.5.1",
@@ -6988,9 +6970,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+checksum = "1580801010e535496706ba011c15f8532df6b42297d2e471fec38ceadd8c0638"
 dependencies = [
  "bitflags 2.9.1",
  "libc",
@@ -7205,9 +7187,9 @@ checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
 name = "mach2"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b955cdeb2a02b9117f121ce63aa52d08ade45de53e48fe6a38b39c10f6f709"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
 dependencies = [
  "libc",
 ]
@@ -7220,7 +7202,7 @@ checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -7329,7 +7311,7 @@ dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
  "regex",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -7339,7 +7321,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd7399781913e5393588a8d8c6a2867bf85fb38eaf2502fdce465aad2dc6f034"
 dependencies = [
  "base64 0.22.1",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "metrics",
  "metrics-util",
  "quanta",
@@ -7384,7 +7366,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -7488,7 +7470,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -7718,12 +7700,11 @@ checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
 name = "notify"
-version = "8.0.0"
+version = "8.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fee8403b3d66ac7b26aee6e40a897d85dc5ce26f44da36b8b73e987cc52e943"
+checksum = "3163f59cd3fa0e9ef8c32f242966a7b9994fd7378366099593e0e73077cd8c97"
 dependencies = [
  "bitflags 2.9.1",
- "filetime",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -7732,7 +7713,7 @@ dependencies = [
  "mio",
  "notify-types",
  "walkdir",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7879,23 +7860,24 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
+checksum = "a973b4e44ce6cad84ce69d797acf9a044532e4184c4f267913d1b546a0727b7a"
 dependencies = [
  "num_enum_derive",
+ "rustversion",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
+checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -7928,12 +7910,13 @@ dependencies = [
 
 [[package]]
 name = "nybbles"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d51b0175c49668a033fe7cc69080110d9833b291566cdf332905f3ad9c68a0"
+checksum = "675b3a54e5b12af997abc8b6638b0aee51a28caedab70d4967e0d5db3a3f1d06"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
+ "cfg-if",
  "proptest",
  "ruint",
  "serde",
@@ -8011,7 +7994,7 @@ dependencies = [
 [[package]]
 name = "op-revm"
 version = "8.0.2"
-source = "git+https://github.com/bluealloy/revm?branch=rakita%2Fcontract_size_limit#3184d8b8e9acccc9c4caf6823b32313a415672a1"
+source = "git+https://github.com/bluealloy/revm?branch=rakita%2Fcontract_size_limit#3fc19c6183fd48cbf930652daeb6e18f5c7d1e27"
 dependencies = [
  "auto_impl",
  "once_cell",
@@ -8073,7 +8056,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -8161,7 +8144,7 @@ dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -8318,7 +8301,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
 ]
 
 [[package]]
@@ -8391,7 +8374,7 @@ dependencies = [
  "phf_shared 0.11.3",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -8429,7 +8412,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -8571,7 +8554,7 @@ dependencies = [
  "comfy-table",
  "either",
  "hashbrown 0.14.5",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "num-traits",
  "once_cell",
  "polars-arrow",
@@ -8662,7 +8645,7 @@ dependencies = [
  "argminmax",
  "arrow2",
  "either",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "memchr",
  "polars-arrow",
  "polars-core",
@@ -8868,12 +8851,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.34"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6837b9e10d61f45f987d50808f83d1ee3d206c66acf650c3e4ae2e1f6ddedf55"
+checksum = "061c1221631e079b26479d25bbf2275bfe5917ae8419cd7e34f13bfc2aa7539a"
 dependencies = [
  "proc-macro2 1.0.95",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -8907,7 +8890,7 @@ checksum = "5676d703dda103cbb035b653a9f11448c0a7216c7926bd35fcb5865475d0c970"
 dependencies = [
  "autocfg 1.5.0",
  "equivalent",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
 ]
 
 [[package]]
@@ -8972,7 +8955,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -9071,7 +9054,7 @@ checksum = "4ee1c9ac207483d5e7db4940700de86a9aae46ef90c48b57f99fe7edb8345e49"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -9568,7 +9551,7 @@ dependencies = [
  "rand 0.8.5",
  "rayon",
  "reipc",
- "reqwest 0.12.20",
+ "reqwest 0.12.22",
  "reth",
  "reth-chainspec",
  "reth-db",
@@ -9587,7 +9570,7 @@ dependencies = [
  "reth-trie",
  "reth-trie-parallel",
  "revm 27.0.2",
- "revm-inspectors 0.23.0",
+ "revm-inspectors 0.25.0",
  "secp256k1 0.30.0",
  "serde",
  "serde_json",
@@ -9675,7 +9658,7 @@ checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -9797,9 +9780,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.20"
+version = "0.12.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabf4c97d9130e2bf606614eb937e86edac8292eaa6f422f995d7e8de1eb1813"
+checksum = "cbc931937e6ca3a06e3b6c0aa7841849b160a90351d6ab467a8b9b9959767531"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -9807,7 +9790,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.10",
+ "h2 0.4.11",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
@@ -9853,7 +9836,7 @@ checksum = "95325155c684b1c89f7765e30bc1c42e4a6da51ca513615660cb8a62ef9a88e3"
 [[package]]
 name = "reth"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-rpc-types",
  "aquamarine",
@@ -9899,7 +9882,7 @@ dependencies = [
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-consensus 1.0.17",
  "alloy-eips 1.0.17",
@@ -9923,7 +9906,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-consensus 1.0.17",
  "alloy-eips 1.0.17",
@@ -9954,7 +9937,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 1.0.17",
@@ -9974,7 +9957,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-genesis",
  "clap 4.5.40",
@@ -9988,7 +9971,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "ahash",
  "alloy-chains",
@@ -10007,7 +9990,7 @@ dependencies = [
  "itertools 0.14.0",
  "lz4",
  "ratatui",
- "reqwest 0.12.20",
+ "reqwest 0.12.22",
  "reth-chainspec",
  "reth-cli",
  "reth-cli-runner",
@@ -10059,7 +10042,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -10069,7 +10052,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-eips 1.0.17",
  "alloy-primitives 1.2.1",
@@ -10087,7 +10070,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-consensus 1.0.17",
  "alloy-eips 1.0.17",
@@ -10107,18 +10090,18 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "convert_case 0.7.1",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "reth-config"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -10133,7 +10116,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-consensus 1.0.17",
  "alloy-primitives 1.2.1",
@@ -10146,7 +10129,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-consensus 1.0.17",
  "alloy-eips 1.0.17",
@@ -10158,7 +10141,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-consensus 1.0.17",
  "alloy-eips 1.0.17",
@@ -10170,7 +10153,7 @@ dependencies = [
  "derive_more 2.0.1",
  "eyre",
  "futures",
- "reqwest 0.12.20",
+ "reqwest 0.12.22",
  "reth-node-api",
  "reth-primitives-traits",
  "reth-tracing",
@@ -10182,7 +10165,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-primitives 1.2.1",
  "derive_more 2.0.1",
@@ -10208,7 +10191,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-consensus 1.0.17",
  "alloy-genesis",
@@ -10236,7 +10219,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-consensus 1.0.17",
  "alloy-genesis",
@@ -10265,7 +10248,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-eips 1.0.17",
  "alloy-primitives 1.2.1",
@@ -10280,7 +10263,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-primitives 1.2.1",
  "alloy-rlp",
@@ -10306,7 +10289,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-primitives 1.2.1",
  "alloy-rlp",
@@ -10330,7 +10313,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-primitives 1.2.1",
  "data-encoding",
@@ -10354,7 +10337,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-consensus 1.0.17",
  "alloy-eips 1.0.17",
@@ -10384,7 +10367,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "aes",
  "alloy-primitives 1.2.1",
@@ -10415,7 +10398,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-consensus 1.0.17",
  "alloy-primitives 1.2.1",
@@ -10437,7 +10420,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-consensus 1.0.17",
  "alloy-eips 1.0.17",
@@ -10462,7 +10445,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-service"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "futures",
  "pin-project",
@@ -10485,7 +10468,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-consensus 1.0.17",
  "alloy-eips 1.0.17",
@@ -10522,7 +10505,7 @@ dependencies = [
  "reth-trie-parallel",
  "reth-trie-sparse",
  "revm 27.0.2",
- "revm-primitives 20.0.0",
+ "revm-primitives",
  "schnellru",
  "thiserror 2.0.12",
  "tokio",
@@ -10532,7 +10515,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-consensus 1.0.17",
  "alloy-rpc-types-engine",
@@ -10559,7 +10542,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-consensus 1.0.17",
  "alloy-eips 1.0.17",
@@ -10575,13 +10558,13 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-primitives 1.2.1",
  "bytes",
  "eyre",
  "futures-util",
- "reqwest 0.12.20",
+ "reqwest 0.12.22",
  "reth-fs-util",
  "sha2 0.10.9",
  "tokio",
@@ -10590,7 +10573,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-consensus 1.0.17",
  "alloy-primitives 1.2.1",
@@ -10614,7 +10597,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -10625,7 +10608,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-chains",
  "alloy-primitives 1.2.1",
@@ -10653,7 +10636,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 1.0.17",
@@ -10674,7 +10657,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-consensus 1.0.17",
  "alloy-eips 1.0.17",
@@ -10733,7 +10716,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-consensus 1.0.17",
  "alloy-eips 1.0.17",
@@ -10749,7 +10732,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-eips 1.0.17",
  "alloy-primitives 1.2.1",
@@ -10767,7 +10750,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-eip2124 0.2.0",
  "alloy-hardforks",
@@ -10780,7 +10763,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-consensus 1.0.17",
  "alloy-eips 1.0.17",
@@ -10809,7 +10792,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-consensus 1.0.17",
  "alloy-eips 1.0.17",
@@ -10827,7 +10810,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -10837,7 +10820,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-consensus 1.0.17",
  "alloy-eips 1.0.17",
@@ -10860,7 +10843,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-consensus 1.0.17",
  "alloy-eips 1.0.17",
@@ -10879,12 +10862,12 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-evm",
  "alloy-primitives 1.2.1",
  "alloy-rlp",
- "nybbles 0.4.0",
+ "nybbles 0.4.1",
  "reth-storage-errors",
  "thiserror 2.0.12",
 ]
@@ -10892,7 +10875,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-consensus 1.0.17",
  "alloy-eips 1.0.17",
@@ -10910,7 +10893,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-consensus 1.0.17",
  "alloy-eips 1.0.17",
@@ -10948,7 +10931,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-eips 1.0.17",
  "alloy-primitives 1.2.1",
@@ -10962,7 +10945,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "serde",
  "serde_json",
@@ -10972,7 +10955,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-consensus 1.0.17",
  "alloy-primitives 1.2.1",
@@ -11000,7 +10983,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "bytes",
  "futures",
@@ -11020,13 +11003,13 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "bitflags 2.9.1",
  "byteorder",
  "dashmap 6.1.0",
  "derive_more 2.0.1",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "parking_lot",
  "reth-mdbx-sys",
  "smallvec",
@@ -11037,7 +11020,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "bindgen",
  "cc",
@@ -11046,7 +11029,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "futures",
  "metrics",
@@ -11058,7 +11041,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-primitives 1.2.1",
 ]
@@ -11066,11 +11049,11 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "futures-util",
  "if-addrs",
- "reqwest 0.12.20",
+ "reqwest 0.12.22",
  "serde_with",
  "thiserror 2.0.12",
  "tokio",
@@ -11080,7 +11063,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-consensus 1.0.17",
  "alloy-eips 1.0.17",
@@ -11135,7 +11118,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-primitives 1.2.1",
  "alloy-rpc-types-admin",
@@ -11158,7 +11141,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-consensus 1.0.17",
  "alloy-eips 1.0.17",
@@ -11180,7 +11163,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-primitives 1.2.1",
  "alloy-rlp",
@@ -11195,7 +11178,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-eip2124 0.2.0",
  "humantime-serde",
@@ -11209,7 +11192,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "anyhow",
  "bincode",
@@ -11226,7 +11209,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -11250,7 +11233,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-consensus 1.0.17",
  "alloy-eips 1.0.17",
@@ -11314,7 +11297,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-consensus 1.0.17",
  "alloy-eips 1.0.17",
@@ -11365,7 +11348,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-eips 1.0.17",
  "alloy-rpc-types-engine",
@@ -11401,7 +11384,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-consensus 1.0.17",
  "alloy-eips 1.0.17",
@@ -11425,7 +11408,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "eyre",
  "http 1.3.1",
@@ -11446,7 +11429,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -11459,7 +11442,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-primitives"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-consensus 1.0.17",
  "alloy-eips 1.0.17",
@@ -11478,7 +11461,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-consensus 1.0.17",
  "alloy-rpc-types",
@@ -11498,7 +11481,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -11510,7 +11493,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-eips 1.0.17",
  "alloy-primitives 1.2.1",
@@ -11529,7 +11512,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-consensus 1.0.17",
  "alloy-rpc-types-engine",
@@ -11539,7 +11522,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-consensus 1.0.17",
  "c-kzg",
@@ -11553,7 +11536,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-consensus 1.0.17",
  "alloy-eips 1.0.17",
@@ -11575,7 +11558,7 @@ dependencies = [
  "rayon",
  "reth-codecs",
  "revm-bytecode 6.0.1",
- "revm-primitives 20.0.0",
+ "revm-primitives",
  "revm-state 7.0.1",
  "secp256k1 0.30.0",
  "serde",
@@ -11586,7 +11569,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-consensus 1.0.17",
  "alloy-eips 1.0.17",
@@ -11631,7 +11614,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-consensus 1.0.17",
  "alloy-eips 1.0.17",
@@ -11659,7 +11642,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-primitives 1.2.1",
  "arbitrary",
@@ -11692,7 +11675,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-protocol"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-consensus 1.0.17",
  "alloy-primitives 1.2.1",
@@ -11711,7 +11694,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-provider"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-consensus 1.0.17",
  "alloy-primitives 1.2.1",
@@ -11738,7 +11721,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-primitives 1.2.1",
  "reth-primitives-traits",
@@ -11751,7 +11734,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-consensus 1.0.17",
  "alloy-dyn-abi",
@@ -11812,7 +11795,7 @@ dependencies = [
  "reth-trie-common",
  "revm 27.0.2",
  "revm-inspectors 0.26.5",
- "revm-primitives 20.0.0",
+ "revm-primitives",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -11827,7 +11810,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-eips 1.0.17",
  "alloy-genesis",
@@ -11855,7 +11838,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -11893,7 +11876,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-consensus 1.0.17",
  "alloy-json-rpc 1.0.17",
@@ -11910,7 +11893,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-eips 1.0.17",
  "alloy-primitives 1.2.1",
@@ -11940,7 +11923,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-consensus 1.0.17",
  "alloy-dyn-abi",
@@ -11985,7 +11968,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-consensus 1.0.17",
  "alloy-eips 1.0.17",
@@ -12028,7 +12011,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.3.1",
@@ -12042,7 +12025,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-eips 1.0.17",
  "alloy-primitives 1.2.1",
@@ -12058,7 +12041,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-consensus 1.0.17",
  "alloy-eips 1.0.17",
@@ -12070,7 +12053,7 @@ dependencies = [
  "itertools 0.14.0",
  "num-traits",
  "rayon",
- "reqwest 0.12.20",
+ "reqwest 0.12.22",
  "reth-codecs",
  "reth-config",
  "reth-consensus",
@@ -12104,7 +12087,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-eips 1.0.17",
  "alloy-primitives 1.2.1",
@@ -12131,7 +12114,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-primitives 1.2.1",
  "arbitrary",
@@ -12145,7 +12128,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-primitives 1.2.1",
  "parking_lot",
@@ -12165,7 +12148,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-primitives 1.2.1",
  "clap 4.5.40",
@@ -12177,7 +12160,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-consensus 1.0.17",
  "alloy-eips 1.0.17",
@@ -12201,7 +12184,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-eips 1.0.17",
  "alloy-primitives 1.2.1",
@@ -12217,7 +12200,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -12235,7 +12218,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -12245,7 +12228,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "clap 4.5.40",
  "eyre",
@@ -12260,7 +12243,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-consensus 1.0.17",
  "alloy-eips 1.0.17",
@@ -12284,7 +12267,7 @@ dependencies = [
  "reth-storage-api",
  "reth-tasks",
  "revm-interpreter 23.0.1",
- "revm-primitives 20.0.0",
+ "revm-primitives",
  "rustc-hash 2.1.1",
  "schnellru",
  "serde",
@@ -12298,7 +12281,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-consensus 1.0.17",
  "alloy-eips 1.0.17",
@@ -12323,7 +12306,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-consensus 1.0.17",
  "alloy-primitives 1.2.1",
@@ -12336,7 +12319,7 @@ dependencies = [
  "derive_more 2.0.1",
  "hash-db",
  "itertools 0.14.0",
- "nybbles 0.4.0",
+ "nybbles 0.4.1",
  "plain_hasher",
  "rayon",
  "reth-codecs",
@@ -12349,7 +12332,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-primitives 1.2.1",
  "reth-db-api",
@@ -12362,7 +12345,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-primitives 1.2.1",
  "alloy-rlp",
@@ -12387,7 +12370,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "alloy-primitives 1.2.1",
  "alloy-rlp",
@@ -12405,34 +12388,34 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.5.0"
-source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#ad1c87fafced4f51cf24db6e56b0d7b653d991af"
 dependencies = [
  "zstd 0.13.3",
 ]
 
 [[package]]
 name = "revm"
-version = "24.0.1"
+version = "26.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d277408ff8d6f747665ad9e52150ab4caf8d5eaf0d787614cf84633c8337b4"
+checksum = "7b2a493c73054a0f6635bad6e840cdbef34838e6e6186974833c901dff7dd709"
 dependencies = [
- "revm-bytecode 4.1.0",
- "revm-context 5.0.1",
- "revm-context-interface 5.0.0",
- "revm-database 4.0.1",
- "revm-database-interface 4.0.1",
- "revm-handler 5.0.1",
- "revm-inspector 5.0.1",
- "revm-interpreter 20.0.0",
- "revm-precompile 21.0.0",
- "revm-primitives 19.2.0",
- "revm-state 4.0.1",
+ "revm-bytecode 5.0.0",
+ "revm-context 7.0.1",
+ "revm-context-interface 7.0.1",
+ "revm-database 6.0.0",
+ "revm-database-interface 6.0.0",
+ "revm-handler 7.0.1",
+ "revm-inspector 7.0.1",
+ "revm-interpreter 22.0.1",
+ "revm-precompile 23.0.0",
+ "revm-primitives",
+ "revm-state 6.0.0",
 ]
 
 [[package]]
 name = "revm"
 version = "27.0.2"
-source = "git+https://github.com/bluealloy/revm?branch=rakita%2Fcontract_size_limit#3184d8b8e9acccc9c4caf6823b32313a415672a1"
+source = "git+https://github.com/bluealloy/revm?branch=rakita%2Fcontract_size_limit#3fc19c6183fd48cbf930652daeb6e18f5c7d1e27"
 dependencies = [
  "revm-bytecode 6.0.1",
  "revm-context 8.0.2",
@@ -12443,162 +12426,163 @@ dependencies = [
  "revm-inspector 8.0.2",
  "revm-interpreter 23.0.1",
  "revm-precompile 24.0.0",
- "revm-primitives 20.0.0",
+ "revm-primitives",
  "revm-state 7.0.1",
 ]
 
 [[package]]
 name = "revm-bytecode"
-version = "4.1.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942fe4724cf552fd28db6b0a2ca5b79e884d40dd8288a4027ed1e9090e0c6f49"
+checksum = "b395ee2212d44fcde20e9425916fee685b5440c3f8e01fabae8b0f07a2fd7f08"
 dependencies = [
  "bitvec",
  "once_cell",
- "revm-primitives 19.2.0",
+ "revm-primitives",
 ]
 
 [[package]]
 name = "revm-bytecode"
 version = "6.0.1"
-source = "git+https://github.com/bluealloy/revm?branch=rakita%2Fcontract_size_limit#3184d8b8e9acccc9c4caf6823b32313a415672a1"
+source = "git+https://github.com/bluealloy/revm?branch=rakita%2Fcontract_size_limit#3fc19c6183fd48cbf930652daeb6e18f5c7d1e27"
 dependencies = [
  "bitvec",
  "once_cell",
  "phf 0.11.3",
- "revm-primitives 20.0.0",
+ "revm-primitives",
  "serde",
 ]
 
 [[package]]
 name = "revm-context"
-version = "5.0.1"
+version = "7.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b01aad49e1233f94cebda48a4e5cef022f7c7ed29b4edf0d202b081af23435ef"
+checksum = "7b97b69d05651509b809eb7215a6563dc64be76a941666c40aabe597ab544d38"
 dependencies = [
  "cfg-if",
  "derive-where",
- "revm-bytecode 4.1.0",
- "revm-context-interface 5.0.0",
- "revm-database-interface 4.0.1",
- "revm-primitives 19.2.0",
- "revm-state 4.0.1",
+ "revm-bytecode 5.0.0",
+ "revm-context-interface 7.0.1",
+ "revm-database-interface 6.0.0",
+ "revm-primitives",
+ "revm-state 6.0.0",
 ]
 
 [[package]]
 name = "revm-context"
 version = "8.0.2"
-source = "git+https://github.com/bluealloy/revm?branch=rakita%2Fcontract_size_limit#3184d8b8e9acccc9c4caf6823b32313a415672a1"
+source = "git+https://github.com/bluealloy/revm?branch=rakita%2Fcontract_size_limit#3fc19c6183fd48cbf930652daeb6e18f5c7d1e27"
 dependencies = [
  "cfg-if",
  "derive-where",
  "revm-bytecode 6.0.1",
  "revm-context-interface 8.0.1",
  "revm-database-interface 7.0.1",
- "revm-primitives 20.0.0",
+ "revm-primitives",
  "revm-state 7.0.1",
  "serde",
 ]
 
 [[package]]
 name = "revm-context-interface"
-version = "5.0.0"
+version = "7.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b844f48a411e62c7dde0f757bf5cce49c85b86d6fc1d3b2722c07f2bec4c3ce"
+checksum = "9f8f4f06a1c43bf8e6148509aa06a6c4d28421541944842b9b11ea1a6e53468f"
 dependencies = [
  "alloy-eip2930 0.2.1",
  "alloy-eip7702 0.6.1",
  "auto_impl",
  "either",
- "revm-database-interface 4.0.1",
- "revm-primitives 19.2.0",
- "revm-state 4.0.1",
+ "revm-database-interface 6.0.0",
+ "revm-primitives",
+ "revm-state 6.0.0",
 ]
 
 [[package]]
 name = "revm-context-interface"
 version = "8.0.1"
-source = "git+https://github.com/bluealloy/revm?branch=rakita%2Fcontract_size_limit#3184d8b8e9acccc9c4caf6823b32313a415672a1"
+source = "git+https://github.com/bluealloy/revm?branch=rakita%2Fcontract_size_limit#3fc19c6183fd48cbf930652daeb6e18f5c7d1e27"
 dependencies = [
  "alloy-eip2930 0.2.1",
  "alloy-eip7702 0.6.1",
  "auto_impl",
  "either",
  "revm-database-interface 7.0.1",
- "revm-primitives 20.0.0",
+ "revm-primitives",
  "revm-state 7.0.1",
  "serde",
 ]
 
 [[package]]
 name = "revm-database"
-version = "4.0.1"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad3fbe34f6bb00a9c3155723b3718b9cb9f17066ba38f9eb101b678cd3626775"
+checksum = "763eb5867a109a85f8e47f548b9d88c9143c0e443ec056742052f059fa32f4f1"
 dependencies = [
- "revm-bytecode 4.1.0",
- "revm-database-interface 4.0.1",
- "revm-primitives 19.2.0",
- "revm-state 4.0.1",
+ "revm-bytecode 5.0.0",
+ "revm-database-interface 6.0.0",
+ "revm-primitives",
+ "revm-state 6.0.0",
 ]
 
 [[package]]
 name = "revm-database"
 version = "7.0.1"
-source = "git+https://github.com/bluealloy/revm?branch=rakita%2Fcontract_size_limit#3184d8b8e9acccc9c4caf6823b32313a415672a1"
+source = "git+https://github.com/bluealloy/revm?branch=rakita%2Fcontract_size_limit#3fc19c6183fd48cbf930652daeb6e18f5c7d1e27"
 dependencies = [
  "alloy-eips 1.0.17",
  "revm-bytecode 6.0.1",
  "revm-database-interface 7.0.1",
- "revm-primitives 20.0.0",
+ "revm-primitives",
  "revm-state 7.0.1",
  "serde",
 ]
 
 [[package]]
 name = "revm-database-interface"
-version = "4.0.1"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b8acd36784a6d95d5b9e1b7be3ce014f1e759abb59df1fa08396b30f71adc2a"
+checksum = "cf5ecd19a5b75b862841113b9abdd864ad4b22e633810e11e6d620e8207e361d"
 dependencies = [
  "auto_impl",
- "revm-primitives 19.2.0",
- "revm-state 4.0.1",
+ "revm-primitives",
+ "revm-state 6.0.0",
 ]
 
 [[package]]
 name = "revm-database-interface"
 version = "7.0.1"
-source = "git+https://github.com/bluealloy/revm?branch=rakita%2Fcontract_size_limit#3184d8b8e9acccc9c4caf6823b32313a415672a1"
+source = "git+https://github.com/bluealloy/revm?branch=rakita%2Fcontract_size_limit#3fc19c6183fd48cbf930652daeb6e18f5c7d1e27"
 dependencies = [
  "auto_impl",
  "either",
- "revm-primitives 20.0.0",
+ "revm-primitives",
  "revm-state 7.0.1",
  "serde",
 ]
 
 [[package]]
 name = "revm-handler"
-version = "5.0.1"
+version = "7.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "481e8c3290ff4fa1c066592fdfeb2b172edfd14d12e6cade6f6f5588cad9359a"
+checksum = "17b61f992beaa7a5fc3f5fcf79f1093624fa1557dc42d36baa42114c2d836b59"
 dependencies = [
  "auto_impl",
- "revm-bytecode 4.1.0",
- "revm-context 5.0.1",
- "revm-context-interface 5.0.0",
- "revm-database-interface 4.0.1",
- "revm-interpreter 20.0.0",
- "revm-precompile 21.0.0",
- "revm-primitives 19.2.0",
- "revm-state 4.0.1",
+ "derive-where",
+ "revm-bytecode 5.0.0",
+ "revm-context 7.0.1",
+ "revm-context-interface 7.0.1",
+ "revm-database-interface 6.0.0",
+ "revm-interpreter 22.0.1",
+ "revm-precompile 23.0.0",
+ "revm-primitives",
+ "revm-state 6.0.0",
 ]
 
 [[package]]
 name = "revm-handler"
 version = "8.0.2"
-source = "git+https://github.com/bluealloy/revm?branch=rakita%2Fcontract_size_limit#3184d8b8e9acccc9c4caf6823b32313a415672a1"
+source = "git+https://github.com/bluealloy/revm?branch=rakita%2Fcontract_size_limit#3fc19c6183fd48cbf930652daeb6e18f5c7d1e27"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -12608,30 +12592,31 @@ dependencies = [
  "revm-database-interface 7.0.1",
  "revm-interpreter 23.0.1",
  "revm-precompile 24.0.0",
- "revm-primitives 20.0.0",
+ "revm-primitives",
  "revm-state 7.0.1",
  "serde",
 ]
 
 [[package]]
 name = "revm-inspector"
-version = "5.0.1"
+version = "7.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc1167ef8937d8867888e63581d8ece729a72073d322119ef4627d813d99ecb"
+checksum = "d7e4400a109a2264f4bf290888ac6d02432b6d5d070492b9dcf134b0c7d51354"
 dependencies = [
  "auto_impl",
- "revm-context 5.0.1",
- "revm-database-interface 4.0.1",
- "revm-handler 5.0.1",
- "revm-interpreter 20.0.0",
- "revm-primitives 19.2.0",
- "revm-state 4.0.1",
+ "either",
+ "revm-context 7.0.1",
+ "revm-database-interface 6.0.0",
+ "revm-handler 7.0.1",
+ "revm-interpreter 22.0.1",
+ "revm-primitives",
+ "revm-state 6.0.0",
 ]
 
 [[package]]
 name = "revm-inspector"
 version = "8.0.2"
-source = "git+https://github.com/bluealloy/revm?branch=rakita%2Fcontract_size_limit#3184d8b8e9acccc9c4caf6823b32313a415672a1"
+source = "git+https://github.com/bluealloy/revm?branch=rakita%2Fcontract_size_limit#3fc19c6183fd48cbf930652daeb6e18f5c7d1e27"
 dependencies = [
  "auto_impl",
  "either",
@@ -12639,7 +12624,7 @@ dependencies = [
  "revm-database-interface 7.0.1",
  "revm-handler 8.0.2",
  "revm-interpreter 23.0.1",
- "revm-primitives 20.0.0",
+ "revm-primitives",
  "revm-state 7.0.1",
  "serde",
  "serde_json",
@@ -12647,16 +12632,16 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.23.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b50ef375dbacefecfdacf8f02afc31df98acc5d8859a6f2b24d121ff2a740a8"
+checksum = "2aabdffc06bdb434d9163e2d63b6fae843559afd300ea3fbeb113b8a0d8ec728"
 dependencies = [
  "alloy-primitives 1.2.1",
  "alloy-rpc-types-eth 1.0.17",
  "alloy-rpc-types-trace",
  "alloy-sol-types 1.2.1",
  "colorchoice",
- "revm 24.0.1",
+ "revm 26.0.1",
  "serde_json",
  "thiserror 2.0.12",
 ]
@@ -12683,31 +12668,31 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "20.0.0"
+version = "22.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5ee65e57375c6639b0f50555e92a4f1b2434349dd32f52e2176f5c711171697"
+checksum = "a2481ef059708772cec0ce6bc4c84b796a40111612efb73b01adf1caed7ff9ac"
 dependencies = [
- "revm-bytecode 4.1.0",
- "revm-context-interface 5.0.0",
- "revm-primitives 19.2.0",
+ "revm-bytecode 5.0.0",
+ "revm-context-interface 7.0.1",
+ "revm-primitives",
 ]
 
 [[package]]
 name = "revm-interpreter"
 version = "23.0.1"
-source = "git+https://github.com/bluealloy/revm?branch=rakita%2Fcontract_size_limit#3184d8b8e9acccc9c4caf6823b32313a415672a1"
+source = "git+https://github.com/bluealloy/revm?branch=rakita%2Fcontract_size_limit#3fc19c6183fd48cbf930652daeb6e18f5c7d1e27"
 dependencies = [
  "revm-bytecode 6.0.1",
  "revm-context-interface 8.0.1",
- "revm-primitives 20.0.0",
+ "revm-primitives",
  "serde",
 ]
 
 [[package]]
 name = "revm-precompile"
-version = "21.0.0"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9311e735123d8d53a02af2aa81877bba185be7c141be7f931bb3d2f3af449c"
+checksum = "6d581e78c8f132832bd00854fb5bf37efd95a52582003da35c25cd2cbfc63849"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -12718,7 +12703,8 @@ dependencies = [
  "cfg-if",
  "k256 0.13.4",
  "once_cell",
- "revm-primitives 19.2.0",
+ "p256",
+ "revm-primitives",
  "ripemd",
  "sha2 0.10.9",
 ]
@@ -12726,7 +12712,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "24.0.0"
-source = "git+https://github.com/bluealloy/revm?branch=rakita%2Fcontract_size_limit#3184d8b8e9acccc9c4caf6823b32313a415672a1"
+source = "git+https://github.com/bluealloy/revm?branch=rakita%2Fcontract_size_limit#3fc19c6183fd48cbf930652daeb6e18f5c7d1e27"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -12742,7 +12728,7 @@ dependencies = [
  "libsecp256k1",
  "once_cell",
  "p256",
- "revm-primitives 20.0.0",
+ "revm-primitives",
  "ripemd",
  "rug",
  "secp256k1 0.31.1",
@@ -12751,18 +12737,8 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "19.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c1588093530ec4442461163be49c433c07a3235d1ca6f6799fef338dacc50d3"
-dependencies = [
- "alloy-primitives 1.2.1",
- "num_enum",
-]
-
-[[package]]
-name = "revm-primitives"
 version = "20.0.0"
-source = "git+https://github.com/bluealloy/revm?branch=rakita%2Fcontract_size_limit#3184d8b8e9acccc9c4caf6823b32313a415672a1"
+source = "git+https://github.com/bluealloy/revm?branch=rakita%2Fcontract_size_limit#3fc19c6183fd48cbf930652daeb6e18f5c7d1e27"
 dependencies = [
  "alloy-primitives 1.2.1",
  "num_enum",
@@ -12771,23 +12747,23 @@ dependencies = [
 
 [[package]]
 name = "revm-state"
-version = "4.0.1"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0040c61c30319254b34507383ba33d85f92949933adf6525a2cede05d165e1fa"
+checksum = "8d6274928dd78f907103740b10800d3c0db6caeca391e75a159c168a1e5c78f8"
 dependencies = [
  "bitflags 2.9.1",
- "revm-bytecode 4.1.0",
- "revm-primitives 19.2.0",
+ "revm-bytecode 5.0.0",
+ "revm-primitives",
 ]
 
 [[package]]
 name = "revm-state"
 version = "7.0.1"
-source = "git+https://github.com/bluealloy/revm?branch=rakita%2Fcontract_size_limit#3184d8b8e9acccc9c4caf6823b32313a415672a1"
+source = "git+https://github.com/bluealloy/revm?branch=rakita%2Fcontract_size_limit#3fc19c6183fd48cbf930652daeb6e18f5c7d1e27"
 dependencies = [
  "bitflags 2.9.1",
  "revm-bytecode 6.0.1",
- "revm-primitives 20.0.0",
+ "revm-primitives",
  "serde",
 ]
 
@@ -13293,7 +13269,7 @@ dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -13310,6 +13286,18 @@ name = "schemars"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -13566,7 +13554,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -13575,7 +13563,7 @@ version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "itoa",
  "memchr",
  "ryu",
@@ -13616,16 +13604,17 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf65a400f8f66fb7b0552869ad70157166676db75ed8181f8104ea91cf9d0b42"
+checksum = "f2c45cd61fefa9db6f254525d46e392b852e0e61d9a1fd36e5bd183450a556d5"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.9.0",
- "schemars",
+ "indexmap 2.10.0",
+ "schemars 0.9.0",
+ "schemars 1.0.4",
  "serde",
  "serde_derive",
  "serde_json",
@@ -13635,14 +13624,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81679d9ed988d5e9a5e6531dc3f2c28efbd639cbd1dfb628df08edea6004da77"
+checksum = "de90945e6565ce0d9a25098082ed4ee4002e047cb59892c318d66821e14bb30f"
 dependencies = [
  "darling 0.20.11",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -14090,7 +14079,7 @@ dependencies = [
  "futures-util",
  "hashlink 0.8.4",
  "hex",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "log",
  "memchr",
  "native-tls",
@@ -14413,7 +14402,7 @@ dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
  "rustversion",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -14426,7 +14415,7 @@ dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
  "rustversion",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -14439,7 +14428,7 @@ dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
  "rustversion",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -14492,9 +14481,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
@@ -14510,7 +14499,7 @@ dependencies = [
  "paste",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -14522,7 +14511,7 @@ dependencies = [
  "paste",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -14560,7 +14549,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -14762,7 +14751,7 @@ dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
  "reqwest 0.11.27",
- "syn 2.0.103",
+ "syn 2.0.104",
  "which",
 ]
 
@@ -14804,7 +14793,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -14815,7 +14804,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -14957,17 +14946,19 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.45.1"
+version = "1.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
+checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
  "libc",
  "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
+ "slab",
  "socket2",
  "tokio-macros",
  "windows-sys 0.52.0",
@@ -14981,7 +14972,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -15135,7 +15126,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -15173,7 +15164,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "hdrhistogram",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "pin-project-lite",
  "slab",
  "sync_wrapper 1.0.2",
@@ -15259,7 +15250,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -15391,7 +15382,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -15811,7 +15802,7 @@ checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -15926,7 +15917,7 @@ dependencies = [
  "log",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
  "wasm-bindgen-shared",
 ]
 
@@ -15961,7 +15952,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -16232,7 +16223,7 @@ checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -16243,7 +16234,7 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -16254,7 +16245,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -16265,7 +16256,7 @@ checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -16276,7 +16267,7 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -16287,7 +16278,7 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -16308,9 +16299,9 @@ dependencies = [
 
 [[package]]
 name = "windows-registry"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3bab093bdd303a1240bb99b8aba8ea8a69ee19d34c9e2ef9594e708a4878820"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
 dependencies = [
  "windows-link",
  "windows-result 0.3.4",
@@ -16735,9 +16726,9 @@ dependencies = [
 
 [[package]]
 name = "xattr"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d65cbf2f12c15564212d48f4e3dfb87923d25d611f2aed18f4cb23f0413d89e"
+checksum = "af3a19837351dc82ba89f8a125e22a3c475f05aba604acc023d62b2739ae2909"
 dependencies = [
  "libc",
  "rustix 1.0.7",
@@ -16802,7 +16793,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
  "synstructure 0.13.2",
 ]
 
@@ -16814,7 +16805,7 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
  "synstructure 0.13.2",
 ]
 
@@ -16835,7 +16826,7 @@ checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -16855,7 +16846,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
  "synstructure 0.13.2",
 ]
 
@@ -16876,7 +16867,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -16920,7 +16911,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -16931,7 +16922,7 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -17019,3 +17010,8 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[patch.unused]]
+name = "alloy-contract"
+version = "1.0.17"
+source = "git+https://github.com/bharath-123/alloy?branch=fusaka%2Fdevnet2#9327426d15283ee2dae1ddf36bd2f5e6691d2e28"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,14 +143,15 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "1.0.12"
-source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#c2584bebb3612351e529e5178f480016316c4120"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9c6ad411efe0f49e0e99b9c7d8749a1eb55f6dbf74a1bc6953ab285b02c4f67"
 dependencies = [
- "alloy-eips 1.0.12",
+ "alloy-eips 1.0.17",
  "alloy-primitives 1.2.1",
  "alloy-rlp",
- "alloy-serde 1.0.12",
- "alloy-trie 0.8.1",
+ "alloy-serde 1.0.17",
+ "alloy-trie 0.9.0",
  "alloy-tx-macros",
  "arbitrary",
  "auto_impl",
@@ -160,7 +161,7 @@ dependencies = [
  "k256 0.13.4",
  "once_cell",
  "rand 0.8.5",
- "secp256k1",
+ "secp256k1 0.30.0",
  "serde",
  "serde_with",
  "thiserror 2.0.12",
@@ -182,14 +183,15 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "1.0.12"
-source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#c2584bebb3612351e529e5178f480016316c4120"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf397edad57b696501702d5887e4e14d7d0bbae9fbb6439e148d361f7254f45"
 dependencies = [
- "alloy-consensus 1.0.12",
- "alloy-eips 1.0.12",
+ "alloy-consensus 1.0.17",
+ "alloy-eips 1.0.17",
  "alloy-primitives 1.2.1",
  "alloy-rlp",
- "alloy-serde 1.0.12",
+ "alloy-serde 1.0.17",
  "arbitrary",
  "serde",
 ]
@@ -313,15 +315,16 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "1.0.12"
-source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#c2584bebb3612351e529e5178f480016316c4120"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "749b8449e4daf7359bdf1dabdba6ce424ff8b1bdc23bdb795661b2e991a08d87"
 dependencies = [
  "alloy-eip2124 0.2.0",
  "alloy-eip2930 0.2.1",
  "alloy-eip7702 0.6.1",
  "alloy-primitives 1.2.1",
  "alloy-rlp",
- "alloy-serde 1.0.12",
+ "alloy-serde 1.0.17",
  "arbitrary",
  "auto_impl",
  "c-kzg",
@@ -335,33 +338,35 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "394b09cf3a32773eedf11828987f9c72dfa74545040be0422e3f5f09a2a3fab9"
+version = "0.13.0"
+source = "git+https://github.com/alloy-rs/evm?branch=fusaka%2Fdevnet2#0f1420656bd704de0ca066414013997a7c455c0d"
 dependencies = [
- "alloy-consensus 1.0.12",
- "alloy-eips 1.0.12",
+ "alloy-consensus 1.0.17",
+ "alloy-eips 1.0.17",
  "alloy-hardforks",
  "alloy-primitives 1.2.1",
+ "alloy-rpc-types-eth 1.0.17",
  "alloy-sol-types 1.2.1",
  "auto_impl",
  "derive_more 2.0.1",
  "op-alloy-consensus",
  "op-revm",
- "revm",
+ "revm 27.0.2",
  "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "alloy-genesis"
-version = "1.0.12"
-source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#c2584bebb3612351e529e5178f480016316c4120"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fcbae2107f3f2df2b02bb7d9e81e8aa730ae371ca9dd7fd0c81c3d0cb78a452"
 dependencies = [
- "alloy-eips 1.0.12",
+ "alloy-eips 1.0.17",
  "alloy-primitives 1.2.1",
- "alloy-serde 1.0.12",
- "alloy-trie 0.8.1",
+ "alloy-serde 1.0.17",
+ "alloy-trie 0.9.0",
  "serde",
+ "serde_with",
 ]
 
 [[package]]
@@ -418,8 +423,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "1.0.12"
-source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#c2584bebb3612351e529e5178f480016316c4120"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc30b0e20fcd0843834ecad2a716661c7b9d5aca2486f8e96b93d5246eb83e06"
 dependencies = [
  "alloy-primitives 1.2.1",
  "alloy-sol-types 1.2.1",
@@ -432,18 +438,19 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "1.0.12"
-source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#c2584bebb3612351e529e5178f480016316c4120"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaeb681024cf71f5ca14f3d812c0a8d8b49f13f7124713538e66d74d3bfe6aff"
 dependencies = [
- "alloy-consensus 1.0.12",
- "alloy-consensus-any 1.0.12",
- "alloy-eips 1.0.12",
- "alloy-json-rpc 1.0.12",
- "alloy-network-primitives 1.0.12",
+ "alloy-consensus 1.0.17",
+ "alloy-consensus-any 1.0.17",
+ "alloy-eips 1.0.17",
+ "alloy-json-rpc 1.0.17",
+ "alloy-network-primitives 1.0.17",
  "alloy-primitives 1.2.1",
  "alloy-rpc-types-any",
- "alloy-rpc-types-eth 1.0.12",
- "alloy-serde 1.0.12",
+ "alloy-rpc-types-eth 1.0.17",
+ "alloy-serde 1.0.17",
  "alloy-signer",
  "alloy-sol-types 1.2.1",
  "async-trait",
@@ -470,21 +477,22 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "1.0.12"
-source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#c2584bebb3612351e529e5178f480016316c4120"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a03ad273e1c55cc481889b4130e82860e33624e6969e9a08854e0f3ebe659295"
 dependencies = [
- "alloy-consensus 1.0.12",
- "alloy-eips 1.0.12",
+ "alloy-consensus 1.0.17",
+ "alloy-eips 1.0.17",
  "alloy-primitives 1.2.1",
- "alloy-serde 1.0.12",
+ "alloy-serde 1.0.17",
  "serde",
 ]
 
 [[package]]
 name = "alloy-node-bindings"
-version = "1.0.12"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e712c068ebe9f690d7d06610ed2e52639cb9570c81420d7a5fb0c9780625086"
+checksum = "0d4f3ab81744547ab8283aa94c9670d3880ac826642e52739e3c4ecbfa84857a"
 dependencies = [
  "alloy-genesis",
  "alloy-hardforks",
@@ -583,19 +591,20 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "1.0.12"
-source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#c2584bebb3612351e529e5178f480016316c4120"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abc164acf8c41c756e76c7aea3be8f0fb03f8a3ef90a33e3ddcea5d1614d8779"
 dependencies = [
  "alloy-chains",
- "alloy-consensus 1.0.12",
- "alloy-eips 1.0.12",
- "alloy-json-rpc 1.0.12",
+ "alloy-consensus 1.0.17",
+ "alloy-eips 1.0.17",
+ "alloy-json-rpc 1.0.17",
  "alloy-network",
- "alloy-network-primitives 1.0.12",
+ "alloy-network-primitives 1.0.17",
  "alloy-primitives 1.2.1",
  "alloy-pubsub",
  "alloy-rpc-client",
- "alloy-rpc-types-eth 1.0.12",
+ "alloy-rpc-types-eth 1.0.17",
  "alloy-signer",
  "alloy-sol-types 1.2.1",
  "alloy-transport",
@@ -625,10 +634,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "1.0.12"
-source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#c2584bebb3612351e529e5178f480016316c4120"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670d155c3e35bcaa252ca706a2757a456c56aa71b80ad1539d07d49b86304e78"
 dependencies = [
- "alloy-json-rpc 1.0.12",
+ "alloy-json-rpc 1.0.17",
  "alloy-primitives 1.2.1",
  "alloy-transport",
  "bimap",
@@ -667,10 +677,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "1.0.12"
-source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#c2584bebb3612351e529e5178f480016316c4120"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c44d31bcb9afad460915fe1fba004a2af5a07a3376c307b9bdfeec3678c209"
 dependencies = [
- "alloy-json-rpc 1.0.12",
+ "alloy-json-rpc 1.0.17",
  "alloy-primitives 1.2.1",
  "alloy-pubsub",
  "alloy-transport",
@@ -694,20 +705,22 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "1.0.12"
-source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#c2584bebb3612351e529e5178f480016316c4120"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ba2cf3d3c6ece87f1c6bb88324a997f28cf0ad7e98d5e0b6fa91c4003c30916"
 dependencies = [
  "alloy-primitives 1.2.1",
  "alloy-rpc-types-engine",
- "alloy-rpc-types-eth 1.0.12",
- "alloy-serde 1.0.12",
+ "alloy-rpc-types-eth 1.0.17",
+ "alloy-serde 1.0.17",
  "serde",
 ]
 
 [[package]]
 name = "alloy-rpc-types-admin"
-version = "1.0.12"
-source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#c2584bebb3612351e529e5178f480016316c4120"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4ce874dde17cc749f1aa8883e0c1431ddda6ba6dd9c9eb9b31d1fb0a6023830"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives 1.2.1",
@@ -717,31 +730,34 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "1.0.12"
-source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#c2584bebb3612351e529e5178f480016316c4120"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65e80e2ffa56956a92af375df1422b239fde6552bd222dfeaeb39f07949060fa"
 dependencies = [
  "alloy-primitives 1.2.1",
- "alloy-rpc-types-eth 1.0.12",
- "alloy-serde 1.0.12",
+ "alloy-rpc-types-eth 1.0.17",
+ "alloy-serde 1.0.17",
  "serde",
 ]
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "1.0.12"
-source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#c2584bebb3612351e529e5178f480016316c4120"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef5b22062142ce3b2ed3374337d4b343437e5de6959397f55d2c9fe2c2ce0162"
 dependencies = [
- "alloy-consensus-any 1.0.12",
- "alloy-rpc-types-eth 1.0.12",
- "alloy-serde 1.0.12",
+ "alloy-consensus-any 1.0.17",
+ "alloy-rpc-types-eth 1.0.17",
+ "alloy-serde 1.0.17",
 ]
 
 [[package]]
 name = "alloy-rpc-types-beacon"
-version = "1.0.12"
-source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#c2584bebb3612351e529e5178f480016316c4120"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "438a7a3a5c5d11877787e324dd1ffd9ab82314ca145513ebe8d12257cbfefb5b"
 dependencies = [
- "alloy-eips 1.0.12",
+ "alloy-eips 1.0.17",
  "alloy-primitives 1.2.1",
  "alloy-rpc-types-engine",
  "ethereum_ssz 0.9.0",
@@ -755,8 +771,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "1.0.12"
-source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#c2584bebb3612351e529e5178f480016316c4120"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f53a2a78b44582e0742ab96d5782842d9b90cebf6ef6ccd8be864ae246fdd0f"
 dependencies = [
  "alloy-primitives 1.2.1",
  "serde",
@@ -764,14 +781,15 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "1.0.12"
-source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#c2584bebb3612351e529e5178f480016316c4120"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7041c3fd4dcd7af95e86280944cc33b4492ac2ddbe02f84079f8019742ec2857"
 dependencies = [
- "alloy-consensus 1.0.12",
- "alloy-eips 1.0.12",
+ "alloy-consensus 1.0.17",
+ "alloy-eips 1.0.17",
  "alloy-primitives 1.2.1",
  "alloy-rlp",
- "alloy-serde 1.0.12",
+ "alloy-serde 1.0.17",
  "derive_more 2.0.1",
  "ethereum_ssz 0.9.0",
  "ethereum_ssz_derive 0.9.0",
@@ -803,16 +821,17 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "1.0.12"
-source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#c2584bebb3612351e529e5178f480016316c4120"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "391e59f81bacbffc7bddd2da3a26d6eec0e2058e9237c279e9b1052bdf21b49e"
 dependencies = [
- "alloy-consensus 1.0.12",
- "alloy-consensus-any 1.0.12",
- "alloy-eips 1.0.12",
- "alloy-network-primitives 1.0.12",
+ "alloy-consensus 1.0.17",
+ "alloy-consensus-any 1.0.17",
+ "alloy-eips 1.0.17",
+ "alloy-network-primitives 1.0.17",
  "alloy-primitives 1.2.1",
  "alloy-rlp",
- "alloy-serde 1.0.12",
+ "alloy-serde 1.0.17",
  "alloy-sol-types 1.2.1",
  "arbitrary",
  "itertools 0.14.0",
@@ -823,26 +842,28 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-mev"
-version = "1.0.12"
-source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#c2584bebb3612351e529e5178f480016316c4120"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de3f327d4cd140eca2c6c27c82c381aba6fa6a32cbb697c146b5607532f82167"
 dependencies = [
- "alloy-consensus 1.0.12",
- "alloy-eips 1.0.12",
+ "alloy-consensus 1.0.17",
+ "alloy-eips 1.0.17",
  "alloy-primitives 1.2.1",
- "alloy-rpc-types-eth 1.0.12",
- "alloy-serde 1.0.12",
+ "alloy-rpc-types-eth 1.0.17",
+ "alloy-serde 1.0.17",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "1.0.12"
-source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#c2584bebb3612351e529e5178f480016316c4120"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29d96238f37e8a72dcf2cf6bead4c4f91dec1c0720b12be10558406e1633a804"
 dependencies = [
  "alloy-primitives 1.2.1",
- "alloy-rpc-types-eth 1.0.12",
- "alloy-serde 1.0.12",
+ "alloy-rpc-types-eth 1.0.17",
+ "alloy-serde 1.0.17",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -850,12 +871,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-txpool"
-version = "1.0.12"
-source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#c2584bebb3612351e529e5178f480016316c4120"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e45d00db47a280d0a6e498b6e63344bccd9485d8860d2e2f06b680200c37ebc2"
 dependencies = [
  "alloy-primitives 1.2.1",
- "alloy-rpc-types-eth 1.0.12",
- "alloy-serde 1.0.12",
+ "alloy-rpc-types-eth 1.0.17",
+ "alloy-serde 1.0.17",
  "serde",
 ]
 
@@ -872,8 +894,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "1.0.12"
-source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#c2584bebb3612351e529e5178f480016316c4120"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea08bc854235d4dff08fd57df8033285c11b8d7548b20c6da218194e7e6035f"
 dependencies = [
  "alloy-primitives 1.2.1",
  "arbitrary",
@@ -883,8 +906,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "1.0.12"
-source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#c2584bebb3612351e529e5178f480016316c4120"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcb3759f85ef5f010a874d9ebd5ee6ce01cac65211510863124e0ebac6552db0"
 dependencies = [
  "alloy-primitives 1.2.1",
  "async-trait",
@@ -897,10 +921,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "1.0.12"
-source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#c2584bebb3612351e529e5178f480016316c4120"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14d95902d29e1290809e1c967a1e974145b44b78f6e3e12fc07a60c1225e3df0"
 dependencies = [
- "alloy-consensus 1.0.12",
+ "alloy-consensus 1.0.17",
  "alloy-network",
  "alloy-primitives 1.2.1",
  "alloy-signer",
@@ -1053,10 +1078,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "1.0.12"
-source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#c2584bebb3612351e529e5178f480016316c4120"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcdf4b7fc58ebb2605b2fc5a33dae5cf15527ea70476978351cc0db1c596ea93"
 dependencies = [
- "alloy-json-rpc 1.0.12",
+ "alloy-json-rpc 1.0.17",
  "alloy-primitives 1.2.1",
  "base64 0.22.1",
  "derive_more 2.0.1",
@@ -1075,10 +1101,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "1.0.12"
-source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#c2584bebb3612351e529e5178f480016316c4120"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c4b0f3a9c28bcd3761504d9eb3578838d6d115c8959fc1ea05f59a3a8f691af"
 dependencies = [
- "alloy-json-rpc 1.0.12",
+ "alloy-json-rpc 1.0.17",
  "alloy-transport",
  "reqwest 0.12.20",
  "serde_json",
@@ -1089,10 +1116,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "1.0.12"
-source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#c2584bebb3612351e529e5178f480016316c4120"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758edb7c266374374e001c50fb1ea89cb5ed48d47ffbf297599f2a557804dd3b"
 dependencies = [
- "alloy-json-rpc 1.0.12",
+ "alloy-json-rpc 1.0.17",
  "alloy-pubsub",
  "alloy-transport",
  "bytes",
@@ -1108,8 +1136,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "1.0.12"
-source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#c2584bebb3612351e529e5178f480016316c4120"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5596b913d1299ee37a9c1bb5118b2639bf253dc1088957bdf2073ae63a6fdfa"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -1133,7 +1162,7 @@ dependencies = [
  "alloy-rlp",
  "arrayvec",
  "derive_more 1.0.0",
- "nybbles",
+ "nybbles 0.3.4",
  "serde",
  "smallvec",
  "tracing",
@@ -1141,9 +1170,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-trie"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "983d99aa81f586cef9dae38443245e585840fcf0fc58b09aee0b1f27aed1d500"
+checksum = "bada1fc392a33665de0dc50d401a3701b62583c655e3522a323490a5da016962"
 dependencies = [
  "alloy-primitives 1.2.1",
  "alloy-rlp",
@@ -1151,7 +1180,7 @@ dependencies = [
  "arrayvec",
  "derive_arbitrary",
  "derive_more 2.0.1",
- "nybbles",
+ "nybbles 0.4.0",
  "proptest",
  "proptest-derive",
  "serde",
@@ -1161,8 +1190,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "1.0.12"
-source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#c2584bebb3612351e529e5178f480016316c4120"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79bf2869e66904b2148c809e7a75e23ca26f5d7b46663a149a1444fb98a69d1d"
 dependencies = [
  "alloy-primitives 1.2.1",
  "darling 0.20.11",
@@ -1810,6 +1840,12 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "az"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
 
 [[package]]
 name = "backon"
@@ -3928,7 +3964,7 @@ dependencies = [
  "k256 0.13.4",
  "log",
  "rand 0.8.5",
- "secp256k1",
+ "secp256k1 0.30.0",
  "serde",
  "sha3",
  "zeroize",
@@ -4042,7 +4078,7 @@ version = "0.1.0"
 dependencies = [
  "alloy-primitives 1.2.1",
  "alloy-rlp",
- "alloy-trie 0.8.1",
+ "alloy-trie 0.9.0",
  "arrayvec",
  "criterion 0.4.0",
  "dashmap 6.1.0",
@@ -4059,7 +4095,7 @@ dependencies = [
  "reth-provider",
  "reth-trie",
  "reth-trie-db",
- "revm",
+ "revm 27.0.2",
  "rustc-hash 2.1.1",
  "serde",
  "serde_json",
@@ -5143,6 +5179,16 @@ dependencies = [
  "serde_json",
  "wasm-bindgen",
  "web-sys",
+]
+
+[[package]]
+name = "gmp-mpfr-sys"
+version = "1.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66d61197a68f6323b9afa616cf83d55d69191e1bf364d4eb7d35ae18defe776"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7874,9 +7920,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8983bb634df7248924ee0c4c3a749609b5abcb082c28fffe3254b3eb3602b307"
 dependencies = [
  "alloy-rlp",
- "arbitrary",
  "const-hex",
  "proptest",
+ "serde",
+ "smallvec",
+]
+
+[[package]]
+name = "nybbles"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d51b0175c49668a033fe7cc69080110d9833b291566cdf332905f3ad9c68a0"
+dependencies = [
+ "alloy-rlp",
+ "arbitrary",
+ "proptest",
+ "ruint",
  "serde",
  "smallvec",
 ]
@@ -7914,15 +7973,15 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "op-alloy-consensus"
-version = "0.17.2"
+version = "0.18.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2423a125ef2daa0d15dacc361805a0b6f76d6acfc6e24a1ff6473582087fe75"
+checksum = "a8719d9b783b29cfa1cf8d591b894805786b9ab4940adc700a57fd0d5b721cf5"
 dependencies = [
- "alloy-consensus 1.0.12",
- "alloy-eips 1.0.12",
+ "alloy-consensus 1.0.17",
+ "alloy-eips 1.0.17",
  "alloy-primitives 1.2.1",
  "alloy-rlp",
- "alloy-serde 1.0.12",
+ "alloy-serde 1.0.17",
  "arbitrary",
  "derive_more 2.0.1",
  "serde",
@@ -7931,37 +7990,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "op-alloy-rpc-types"
-version = "0.17.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f82a315004b6720fbf756afdcfdc97ea7ddbcdccfec86ea7df7562bb0da29a3f"
-dependencies = [
- "alloy-consensus 1.0.12",
- "alloy-eips 1.0.12",
- "alloy-network-primitives 1.0.12",
- "alloy-primitives 1.2.1",
- "alloy-rpc-types-eth 1.0.12",
- "alloy-serde 1.0.12",
- "derive_more 2.0.1",
- "op-alloy-consensus",
- "serde",
- "serde_json",
- "thiserror 2.0.12",
-]
-
-[[package]]
 name = "op-alloy-rpc-types-engine"
-version = "0.17.2"
+version = "0.18.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47aea08d8ad3f533df0c5082d3e93428a4c57898b7ade1be928fa03918f22e71"
+checksum = "6a4559d84f079b3fdfd01e4ee0bb118025e92105fbb89736f5d77ab3ca261698"
 dependencies = [
- "alloy-consensus 1.0.12",
- "alloy-eips 1.0.12",
+ "alloy-consensus 1.0.17",
+ "alloy-eips 1.0.17",
  "alloy-primitives 1.2.1",
  "alloy-rlp",
  "alloy-rpc-types-engine",
  "derive_more 2.0.1",
  "ethereum_ssz 0.9.0",
+ "ethereum_ssz_derive 0.9.0",
  "op-alloy-consensus",
  "snap",
  "thiserror 2.0.12",
@@ -7969,12 +8010,12 @@ dependencies = [
 
 [[package]]
 name = "op-revm"
-version = "5.0.1"
-source = "git+https://github.com/bluealloy/revm?branch=fusaka%2Fdevnet2#e8fb036fc6d9c2dcb6d67b4c319b827dc8b0a0d3"
+version = "8.0.2"
+source = "git+https://github.com/bluealloy/revm?branch=rakita%2Fcontract_size_limit#3184d8b8e9acccc9c4caf6823b32313a415672a1"
 dependencies = [
  "auto_impl",
  "once_cell",
- "revm",
+ "revm 27.0.2",
  "serde",
 ]
 
@@ -9470,12 +9511,12 @@ version = "0.1.0"
 dependencies = [
  "ahash",
  "alloy-chains",
- "alloy-consensus 1.0.12",
- "alloy-eips 1.0.12",
+ "alloy-consensus 1.0.17",
+ "alloy-eips 1.0.17",
  "alloy-evm",
- "alloy-json-rpc 1.0.12",
+ "alloy-json-rpc 1.0.17",
  "alloy-network",
- "alloy-network-primitives 1.0.12",
+ "alloy-network-primitives 1.0.17",
  "alloy-node-bindings",
  "alloy-primitives 1.2.1",
  "alloy-provider",
@@ -9483,7 +9524,7 @@ dependencies = [
  "alloy-rpc-types",
  "alloy-rpc-types-beacon",
  "alloy-rpc-types-engine",
- "alloy-rpc-types-eth 1.0.12",
+ "alloy-rpc-types-eth 1.0.17",
  "alloy-signer-local",
  "assert_matches",
  "async-trait",
@@ -9533,6 +9574,7 @@ dependencies = [
  "reth-db",
  "reth-db-common",
  "reth-errors",
+ "reth-ethereum-primitives",
  "reth-evm",
  "reth-evm-ethereum",
  "reth-node-api",
@@ -9544,9 +9586,9 @@ dependencies = [
  "reth-provider",
  "reth-trie",
  "reth-trie-parallel",
- "revm",
- "revm-inspectors",
- "secp256k1",
+ "revm 27.0.2",
+ "revm-inspectors 0.23.0",
+ "secp256k1 0.30.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -9810,8 +9852,8 @@ checksum = "95325155c684b1c89f7765e30bc1c42e4a6da51ca513615660cb8a62ef9a88e3"
 
 [[package]]
 name = "reth"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
  "alloy-rpc-types",
  "aquamarine",
@@ -9844,9 +9886,9 @@ dependencies = [
  "reth-rpc",
  "reth-rpc-api",
  "reth-rpc-builder",
+ "reth-rpc-convert",
  "reth-rpc-eth-types",
  "reth-rpc-server-types",
- "reth-rpc-types-compat",
  "reth-tasks",
  "reth-tokio-util",
  "reth-transaction-pool",
@@ -9856,11 +9898,11 @@ dependencies = [
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
- "alloy-consensus 1.0.12",
- "alloy-eips 1.0.12",
+ "alloy-consensus 1.0.17",
+ "alloy-eips 1.0.17",
  "alloy-primitives 1.2.1",
  "futures-core",
  "futures-util",
@@ -9880,11 +9922,11 @@ dependencies = [
 
 [[package]]
 name = "reth-chain-state"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
- "alloy-consensus 1.0.12",
- "alloy-eips 1.0.12",
+ "alloy-consensus 1.0.17",
+ "alloy-eips 1.0.17",
  "alloy-primitives 1.2.1",
  "alloy-signer",
  "alloy-signer-local",
@@ -9901,8 +9943,8 @@ dependencies = [
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-trie",
- "revm-database",
- "revm-state",
+ "revm-database 7.0.1",
+ "revm-state 7.0.1",
  "serde",
  "tokio",
  "tokio-stream",
@@ -9911,19 +9953,18 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
  "alloy-chains",
- "alloy-consensus 1.0.12",
- "alloy-eips 1.0.12",
+ "alloy-consensus 1.0.17",
+ "alloy-eips 1.0.17",
  "alloy-evm",
  "alloy-genesis",
  "alloy-primitives 1.2.1",
- "alloy-trie 0.8.1",
+ "alloy-trie 0.9.0",
  "auto_impl",
  "derive_more 2.0.1",
- "itertools 0.14.0",
  "reth-ethereum-forks",
  "reth-network-peers",
  "reth-primitives-traits",
@@ -9932,8 +9973,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
  "alloy-genesis",
  "clap 4.5.40",
@@ -9946,13 +9987,13 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-commands"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
  "ahash",
  "alloy-chains",
- "alloy-consensus 1.0.12",
- "alloy-eips 1.0.12",
+ "alloy-consensus 1.0.17",
+ "alloy-eips 1.0.17",
  "alloy-primitives 1.2.1",
  "alloy-rlp",
  "backon",
@@ -10005,7 +10046,7 @@ dependencies = [
  "reth-static-file-types",
  "reth-trie",
  "reth-trie-db",
- "secp256k1",
+ "secp256k1 0.30.0",
  "serde",
  "serde_json",
  "tar",
@@ -10017,8 +10058,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-runner"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -10027,17 +10068,17 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-util"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
- "alloy-eips 1.0.12",
+ "alloy-eips 1.0.17",
  "alloy-primitives 1.2.1",
  "cfg-if",
  "eyre",
  "libc",
  "rand 0.8.5",
  "reth-fs-util",
- "secp256k1",
+ "secp256k1 0.30.0",
  "serde",
  "thiserror 2.0.12",
  "tikv-jemallocator",
@@ -10045,14 +10086,14 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
- "alloy-consensus 1.0.12",
- "alloy-eips 1.0.12",
+ "alloy-consensus 1.0.17",
+ "alloy-eips 1.0.17",
  "alloy-genesis",
  "alloy-primitives 1.2.1",
- "alloy-trie 0.8.1",
+ "alloy-trie 0.9.0",
  "arbitrary",
  "bytes",
  "modular-bitfield",
@@ -10065,8 +10106,8 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
  "convert_case 0.7.1",
  "proc-macro2 1.0.95",
@@ -10076,8 +10117,8 @@ dependencies = [
 
 [[package]]
 name = "reth-config"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -10091,10 +10132,10 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
- "alloy-consensus 1.0.12",
+ "alloy-consensus 1.0.17",
  "alloy-primitives 1.2.1",
  "auto_impl",
  "reth-execution-types",
@@ -10104,11 +10145,11 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
- "alloy-consensus 1.0.12",
- "alloy-eips 1.0.12",
+ "alloy-consensus 1.0.17",
+ "alloy-eips 1.0.17",
  "reth-chainspec",
  "reth-consensus",
  "reth-primitives-traits",
@@ -10116,12 +10157,12 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-debug-client"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
- "alloy-consensus 1.0.12",
- "alloy-eips 1.0.12",
- "alloy-json-rpc 1.0.12",
+ "alloy-consensus 1.0.17",
+ "alloy-eips 1.0.17",
+ "alloy-json-rpc 1.0.17",
  "alloy-primitives 1.2.1",
  "alloy-provider",
  "alloy-rpc-types-engine",
@@ -10140,8 +10181,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
  "alloy-primitives 1.2.1",
  "derive_more 2.0.1",
@@ -10166,10 +10207,10 @@ dependencies = [
 
 [[package]]
 name = "reth-db-api"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
- "alloy-consensus 1.0.12",
+ "alloy-consensus 1.0.17",
  "alloy-genesis",
  "alloy-primitives 1.2.1",
  "arbitrary",
@@ -10194,10 +10235,10 @@ dependencies = [
 
 [[package]]
 name = "reth-db-common"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
- "alloy-consensus 1.0.12",
+ "alloy-consensus 1.0.17",
  "alloy-genesis",
  "alloy-primitives 1.2.1",
  "boyer-moore-magiclen",
@@ -10223,10 +10264,10 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
- "alloy-eips 1.0.12",
+ "alloy-eips 1.0.17",
  "alloy-primitives 1.2.1",
  "arbitrary",
  "bytes",
@@ -10238,8 +10279,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv4"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
  "alloy-primitives 1.2.1",
  "alloy-rlp",
@@ -10254,7 +10295,7 @@ dependencies = [
  "reth-net-nat",
  "reth-network-peers",
  "schnellru",
- "secp256k1",
+ "secp256k1 0.30.0",
  "serde",
  "thiserror 2.0.12",
  "tokio",
@@ -10264,8 +10305,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
  "alloy-primitives 1.2.1",
  "alloy-rlp",
@@ -10280,7 +10321,7 @@ dependencies = [
  "reth-ethereum-forks",
  "reth-metrics",
  "reth-network-peers",
- "secp256k1",
+ "secp256k1 0.30.0",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -10288,8 +10329,8 @@ dependencies = [
 
 [[package]]
 name = "reth-dns-discovery"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
  "alloy-primitives 1.2.1",
  "data-encoding",
@@ -10301,7 +10342,7 @@ dependencies = [
  "reth-network-peers",
  "reth-tokio-util",
  "schnellru",
- "secp256k1",
+ "secp256k1 0.30.0",
  "serde",
  "serde_with",
  "thiserror 2.0.12",
@@ -10312,11 +10353,11 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
- "alloy-consensus 1.0.12",
- "alloy-eips 1.0.12",
+ "alloy-consensus 1.0.17",
+ "alloy-eips 1.0.17",
  "alloy-primitives 1.2.1",
  "alloy-rlp",
  "futures",
@@ -10342,8 +10383,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
  "aes",
  "alloy-primitives 1.2.1",
@@ -10360,7 +10401,7 @@ dependencies = [
  "pin-project",
  "rand 0.8.5",
  "reth-network-peers",
- "secp256k1",
+ "secp256k1 0.30.0",
  "sha2 0.10.9",
  "sha3",
  "thiserror 2.0.12",
@@ -10373,10 +10414,10 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-local"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
- "alloy-consensus 1.0.12",
+ "alloy-consensus 1.0.17",
  "alloy-primitives 1.2.1",
  "alloy-rpc-types-engine",
  "eyre",
@@ -10395,11 +10436,11 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
- "alloy-consensus 1.0.12",
- "alloy-eips 1.0.12",
+ "alloy-consensus 1.0.17",
+ "alloy-eips 1.0.17",
  "alloy-primitives 1.2.1",
  "alloy-rpc-types-engine",
  "auto_impl",
@@ -10420,8 +10461,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-service"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
  "futures",
  "pin-project",
@@ -10443,11 +10484,11 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-tree"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
- "alloy-consensus 1.0.12",
- "alloy-eips 1.0.12",
+ "alloy-consensus 1.0.17",
+ "alloy-eips 1.0.17",
  "alloy-evm",
  "alloy-primitives 1.2.1",
  "alloy-rlp",
@@ -10480,8 +10521,8 @@ dependencies = [
  "reth-trie-db",
  "reth-trie-parallel",
  "reth-trie-sparse",
- "revm",
- "revm-primitives",
+ "revm 27.0.2",
+ "revm-primitives 20.0.0",
  "schnellru",
  "thiserror 2.0.12",
  "tokio",
@@ -10490,10 +10531,10 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-util"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
- "alloy-consensus 1.0.12",
+ "alloy-consensus 1.0.17",
  "alloy-rpc-types-engine",
  "eyre",
  "futures",
@@ -10517,11 +10558,11 @@ dependencies = [
 
 [[package]]
 name = "reth-era"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
- "alloy-consensus 1.0.12",
- "alloy-eips 1.0.12",
+ "alloy-consensus 1.0.17",
+ "alloy-eips 1.0.17",
  "alloy-primitives 1.2.1",
  "alloy-rlp",
  "ethereum_ssz 0.9.0",
@@ -10533,8 +10574,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era-downloader"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
  "alloy-primitives 1.2.1",
  "bytes",
@@ -10548,19 +10589,23 @@ dependencies = [
 
 [[package]]
 name = "reth-era-utils"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
+ "alloy-consensus 1.0.17",
  "alloy-primitives 1.2.1",
+ "alloy-rlp",
  "eyre",
  "futures-util",
  "reth-db-api",
  "reth-era",
  "reth-era-downloader",
+ "reth-ethereum-primitives",
  "reth-etl",
  "reth-fs-util",
  "reth-primitives-traits",
  "reth-provider",
+ "reth-stages-types",
  "reth-storage-api",
  "tokio",
  "tracing",
@@ -10568,8 +10613,8 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -10579,8 +10624,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
  "alloy-chains",
  "alloy-primitives 1.2.1",
@@ -10607,12 +10652,12 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
  "alloy-chains",
- "alloy-consensus 1.0.12",
- "alloy-eips 1.0.12",
+ "alloy-consensus 1.0.17",
+ "alloy-eips 1.0.17",
  "alloy-hardforks",
  "alloy-primitives 1.2.1",
  "alloy-rlp",
@@ -10628,11 +10673,11 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-cli"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
- "alloy-consensus 1.0.12",
- "alloy-eips 1.0.12",
+ "alloy-consensus 1.0.17",
+ "alloy-eips 1.0.17",
  "alloy-primitives 1.2.1",
  "alloy-rlp",
  "alloy-rpc-types",
@@ -10687,11 +10732,11 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
- "alloy-consensus 1.0.12",
- "alloy-eips 1.0.12",
+ "alloy-consensus 1.0.17",
+ "alloy-eips 1.0.17",
  "alloy-primitives 1.2.1",
  "reth-chainspec",
  "reth-consensus",
@@ -10703,10 +10748,10 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
- "alloy-eips 1.0.12",
+ "alloy-eips 1.0.17",
  "alloy-primitives 1.2.1",
  "alloy-rlp",
  "alloy-rpc-types-engine",
@@ -10721,8 +10766,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
  "alloy-eip2124 0.2.0",
  "alloy-hardforks",
@@ -10734,11 +10779,11 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
- "alloy-consensus 1.0.12",
- "alloy-eips 1.0.12",
+ "alloy-consensus 1.0.17",
+ "alloy-eips 1.0.17",
  "alloy-primitives 1.2.1",
  "alloy-rlp",
  "alloy-rpc-types-engine",
@@ -10757,17 +10802,17 @@ dependencies = [
  "reth-revm",
  "reth-storage-api",
  "reth-transaction-pool",
- "revm",
+ "revm 27.0.2",
  "tracing",
 ]
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
- "alloy-consensus 1.0.12",
- "alloy-eips 1.0.12",
+ "alloy-consensus 1.0.17",
+ "alloy-eips 1.0.17",
  "alloy-primitives 1.2.1",
  "alloy-rlp",
  "arbitrary",
@@ -10781,8 +10826,8 @@ dependencies = [
 
 [[package]]
 name = "reth-etl"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -10791,11 +10836,11 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
- "alloy-consensus 1.0.12",
- "alloy-eips 1.0.12",
+ "alloy-consensus 1.0.17",
+ "alloy-eips 1.0.17",
  "alloy-evm",
  "alloy-primitives 1.2.1",
  "auto_impl",
@@ -10809,16 +10854,16 @@ dependencies = [
  "reth-storage-api",
  "reth-storage-errors",
  "reth-trie-common",
- "revm",
+ "revm 27.0.2",
 ]
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
- "alloy-consensus 1.0.12",
- "alloy-eips 1.0.12",
+ "alloy-consensus 1.0.17",
+ "alloy-eips 1.0.17",
  "alloy-evm",
  "alloy-primitives 1.2.1",
  "derive_more 2.0.1",
@@ -10828,47 +10873,47 @@ dependencies = [
  "reth-evm",
  "reth-execution-types",
  "reth-primitives-traits",
- "revm",
+ "revm 27.0.2",
 ]
 
 [[package]]
 name = "reth-execution-errors"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
  "alloy-evm",
  "alloy-primitives 1.2.1",
  "alloy-rlp",
- "nybbles",
+ "nybbles 0.4.0",
  "reth-storage-errors",
  "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "reth-execution-types"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
- "alloy-consensus 1.0.12",
- "alloy-eips 1.0.12",
+ "alloy-consensus 1.0.17",
+ "alloy-eips 1.0.17",
  "alloy-evm",
  "alloy-primitives 1.2.1",
  "derive_more 2.0.1",
  "reth-ethereum-primitives",
  "reth-primitives-traits",
  "reth-trie-common",
- "revm",
+ "revm 27.0.2",
  "serde",
  "serde_with",
 ]
 
 [[package]]
 name = "reth-exex"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
- "alloy-consensus 1.0.12",
- "alloy-eips 1.0.12",
+ "alloy-consensus 1.0.17",
+ "alloy-eips 1.0.17",
  "alloy-primitives 1.2.1",
  "eyre",
  "futures",
@@ -10902,10 +10947,10 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-types"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
- "alloy-eips 1.0.12",
+ "alloy-eips 1.0.17",
  "alloy-primitives 1.2.1",
  "reth-chain-state",
  "reth-execution-types",
@@ -10916,8 +10961,8 @@ dependencies = [
 
 [[package]]
 name = "reth-fs-util"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
  "serde",
  "serde_json",
@@ -10926,10 +10971,10 @@ dependencies = [
 
 [[package]]
 name = "reth-invalid-block-hooks"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
- "alloy-consensus 1.0.12",
+ "alloy-consensus 1.0.17",
  "alloy-primitives 1.2.1",
  "alloy-rlp",
  "alloy-rpc-types-debug",
@@ -10946,16 +10991,16 @@ dependencies = [
  "reth-rpc-api",
  "reth-tracing",
  "reth-trie",
- "revm-bytecode",
- "revm-database",
+ "revm-bytecode 6.0.1",
+ "revm-database 7.0.1",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "reth-ipc"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
  "bytes",
  "futures",
@@ -10974,8 +11019,8 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
  "bitflags 2.9.1",
  "byteorder",
@@ -10991,8 +11036,8 @@ dependencies = [
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
  "bindgen",
  "cc",
@@ -11000,8 +11045,8 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
  "futures",
  "metrics",
@@ -11012,16 +11057,16 @@ dependencies = [
 
 [[package]]
 name = "reth-net-banlist"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
  "alloy-primitives 1.2.1",
 ]
 
 [[package]]
 name = "reth-net-nat"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -11034,11 +11079,11 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
- "alloy-consensus 1.0.12",
- "alloy-eips 1.0.12",
+ "alloy-consensus 1.0.17",
+ "alloy-eips 1.0.17",
  "alloy-primitives 1.2.1",
  "alloy-rlp",
  "aquamarine",
@@ -11077,7 +11122,7 @@ dependencies = [
  "reth-transaction-pool",
  "rustc-hash 2.1.1",
  "schnellru",
- "secp256k1",
+ "secp256k1 0.30.0",
  "serde",
  "smallvec",
  "thiserror 2.0.12",
@@ -11089,8 +11134,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
  "alloy-primitives 1.2.1",
  "alloy-rpc-types-admin",
@@ -11112,11 +11157,11 @@ dependencies = [
 
 [[package]]
 name = "reth-network-p2p"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
- "alloy-consensus 1.0.12",
- "alloy-eips 1.0.12",
+ "alloy-consensus 1.0.17",
+ "alloy-eips 1.0.17",
  "alloy-primitives 1.2.1",
  "auto_impl",
  "derive_more 2.0.1",
@@ -11134,13 +11179,13 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
  "alloy-primitives 1.2.1",
  "alloy-rlp",
  "enr 0.13.0",
- "secp256k1",
+ "secp256k1 0.30.0",
  "serde_with",
  "thiserror 2.0.12",
  "tokio",
@@ -11149,8 +11194,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
  "alloy-eip2124 0.2.0",
  "humantime-serde",
@@ -11163,8 +11208,8 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
  "anyhow",
  "bincode",
@@ -11180,8 +11225,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -11204,11 +11249,11 @@ dependencies = [
 
 [[package]]
 name = "reth-node-builder"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
- "alloy-consensus 1.0.12",
- "alloy-eips 1.0.12",
+ "alloy-consensus 1.0.17",
+ "alloy-eips 1.0.17",
  "alloy-primitives 1.2.1",
  "alloy-provider",
  "alloy-rpc-types",
@@ -11259,7 +11304,7 @@ dependencies = [
  "reth-tokio-util",
  "reth-tracing",
  "reth-transaction-pool",
- "secp256k1",
+ "secp256k1 0.30.0",
  "serde_json",
  "tokio",
  "tokio-stream",
@@ -11268,11 +11313,11 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
- "alloy-consensus 1.0.12",
- "alloy-eips 1.0.12",
+ "alloy-consensus 1.0.17",
+ "alloy-eips 1.0.17",
  "alloy-primitives 1.2.1",
  "alloy-rpc-types-engine",
  "clap 4.5.40",
@@ -11297,15 +11342,15 @@ dependencies = [
  "reth-network-peers",
  "reth-primitives-traits",
  "reth-prune-types",
+ "reth-rpc-convert",
  "reth-rpc-eth-types",
  "reth-rpc-server-types",
- "reth-rpc-types-compat",
  "reth-stages-types",
  "reth-storage-api",
  "reth-storage-errors",
  "reth-tracing",
  "reth-transaction-pool",
- "secp256k1",
+ "secp256k1 0.30.0",
  "serde",
  "shellexpand",
  "strum 0.27.1",
@@ -11319,12 +11364,12 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethereum"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
- "alloy-eips 1.0.12",
+ "alloy-eips 1.0.17",
  "alloy-rpc-types-engine",
- "alloy-rpc-types-eth 1.0.12",
+ "alloy-rpc-types-eth 1.0.17",
  "eyre",
  "reth-chainspec",
  "reth-consensus",
@@ -11350,16 +11395,16 @@ dependencies = [
  "reth-tracing",
  "reth-transaction-pool",
  "reth-trie-db",
- "revm",
+ "revm 27.0.2",
 ]
 
 [[package]]
 name = "reth-node-events"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
- "alloy-consensus 1.0.12",
- "alloy-eips 1.0.12",
+ "alloy-consensus 1.0.17",
+ "alloy-eips 1.0.17",
  "alloy-primitives 1.2.1",
  "alloy-rpc-types-engine",
  "derive_more 2.0.1",
@@ -11379,8 +11424,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-metrics"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
  "eyre",
  "http 1.3.1",
@@ -11400,8 +11445,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-types"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -11413,11 +11458,11 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-primitives"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
- "alloy-consensus 1.0.12",
- "alloy-eips 1.0.12",
+ "alloy-consensus 1.0.17",
+ "alloy-eips 1.0.17",
  "alloy-primitives 1.2.1",
  "alloy-rlp",
  "arbitrary",
@@ -11432,10 +11477,10 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
- "alloy-consensus 1.0.12",
+ "alloy-consensus 1.0.17",
  "alloy-rpc-types",
  "futures-util",
  "metrics",
@@ -11452,8 +11497,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder-primitives"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -11464,10 +11509,10 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
- "alloy-eips 1.0.12",
+ "alloy-eips 1.0.17",
  "alloy-primitives 1.2.1",
  "alloy-rpc-types-engine",
  "auto_impl",
@@ -11483,20 +11528,20 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
- "alloy-consensus 1.0.12",
+ "alloy-consensus 1.0.17",
  "alloy-rpc-types-engine",
  "reth-primitives-traits",
 ]
 
 [[package]]
 name = "reth-primitives"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
- "alloy-consensus 1.0.12",
+ "alloy-consensus 1.0.17",
  "c-kzg",
  "once_cell",
  "reth-ethereum-forks",
@@ -11507,15 +11552,16 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
- "alloy-consensus 1.0.12",
- "alloy-eips 1.0.12",
+ "alloy-consensus 1.0.17",
+ "alloy-eips 1.0.17",
  "alloy-genesis",
  "alloy-primitives 1.2.1",
  "alloy-rlp",
- "alloy-trie 0.8.1",
+ "alloy-rpc-types-eth 1.0.17",
+ "alloy-trie 0.9.0",
  "arbitrary",
  "auto_impl",
  "byteorder",
@@ -11528,10 +11574,10 @@ dependencies = [
  "proptest-arbitrary-interop",
  "rayon",
  "reth-codecs",
- "revm-bytecode",
- "revm-primitives",
- "revm-state",
- "secp256k1",
+ "revm-bytecode 6.0.1",
+ "revm-primitives 20.0.0",
+ "revm-state 7.0.1",
+ "secp256k1 0.30.0",
  "serde",
  "serde_with",
  "thiserror 2.0.12",
@@ -11539,11 +11585,11 @@ dependencies = [
 
 [[package]]
 name = "reth-provider"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
- "alloy-consensus 1.0.12",
- "alloy-eips 1.0.12",
+ "alloy-consensus 1.0.17",
+ "alloy-eips 1.0.17",
  "alloy-primitives 1.2.1",
  "alloy-rpc-types-engine",
  "dashmap 6.1.0",
@@ -11575,8 +11621,8 @@ dependencies = [
  "reth-storage-errors",
  "reth-trie",
  "reth-trie-db",
- "revm-database",
- "revm-state",
+ "revm-database 7.0.1",
+ "revm-state 7.0.1",
  "strum 0.27.1",
  "tokio",
  "tracing",
@@ -11584,11 +11630,11 @@ dependencies = [
 
 [[package]]
 name = "reth-prune"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
- "alloy-consensus 1.0.12",
- "alloy-eips 1.0.12",
+ "alloy-consensus 1.0.17",
+ "alloy-eips 1.0.17",
  "alloy-primitives 1.2.1",
  "itertools 0.14.0",
  "metrics",
@@ -11612,8 +11658,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
  "alloy-primitives 1.2.1",
  "arbitrary",
@@ -11645,10 +11691,10 @@ dependencies = [
 
 [[package]]
 name = "reth-ress-protocol"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
- "alloy-consensus 1.0.12",
+ "alloy-consensus 1.0.17",
  "alloy-primitives 1.2.1",
  "alloy-rlp",
  "futures",
@@ -11664,10 +11710,10 @@ dependencies = [
 
 [[package]]
 name = "reth-ress-provider"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
- "alloy-consensus 1.0.12",
+ "alloy-consensus 1.0.17",
  "alloy-primitives 1.2.1",
  "eyre",
  "futures",
@@ -11691,25 +11737,25 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
  "alloy-primitives 1.2.1",
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-storage-errors",
  "reth-trie",
- "revm",
+ "revm 27.0.2",
 ]
 
 [[package]]
 name = "reth-rpc"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
- "alloy-consensus 1.0.12",
+ "alloy-consensus 1.0.17",
  "alloy-dyn-abi",
- "alloy-eips 1.0.12",
+ "alloy-eips 1.0.17",
  "alloy-evm",
  "alloy-genesis",
  "alloy-network",
@@ -11720,11 +11766,11 @@ dependencies = [
  "alloy-rpc-types-beacon",
  "alloy-rpc-types-debug",
  "alloy-rpc-types-engine",
- "alloy-rpc-types-eth 1.0.12",
+ "alloy-rpc-types-eth 1.0.17",
  "alloy-rpc-types-mev",
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
- "alloy-serde 1.0.12",
+ "alloy-serde 1.0.17",
  "alloy-signer",
  "alloy-signer-local",
  "async-trait",
@@ -11745,6 +11791,7 @@ dependencies = [
  "reth-errors",
  "reth-ethereum-primitives",
  "reth-evm",
+ "reth-evm-ethereum",
  "reth-execution-types",
  "reth-metrics",
  "reth-network-api",
@@ -11754,18 +11801,18 @@ dependencies = [
  "reth-primitives-traits",
  "reth-revm",
  "reth-rpc-api",
+ "reth-rpc-convert",
  "reth-rpc-engine-api",
  "reth-rpc-eth-api",
  "reth-rpc-eth-types",
  "reth-rpc-server-types",
- "reth-rpc-types-compat",
  "reth-storage-api",
  "reth-tasks",
  "reth-transaction-pool",
  "reth-trie-common",
- "revm",
- "revm-inspectors",
- "revm-primitives",
+ "revm 27.0.2",
+ "revm-inspectors 0.26.5",
+ "revm-primitives 20.0.0",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -11779,12 +11826,12 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
- "alloy-eips 1.0.12",
+ "alloy-eips 1.0.17",
  "alloy-genesis",
- "alloy-json-rpc 1.0.12",
+ "alloy-json-rpc 1.0.17",
  "alloy-primitives 1.2.1",
  "alloy-rpc-types",
  "alloy-rpc-types-admin",
@@ -11792,11 +11839,11 @@ dependencies = [
  "alloy-rpc-types-beacon",
  "alloy-rpc-types-debug",
  "alloy-rpc-types-engine",
- "alloy-rpc-types-eth 1.0.12",
+ "alloy-rpc-types-eth 1.0.17",
  "alloy-rpc-types-mev",
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
- "alloy-serde 1.0.12",
+ "alloy-serde 1.0.17",
  "jsonrpsee 0.25.1",
  "reth-chain-state",
  "reth-engine-primitives",
@@ -11807,8 +11854,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-builder"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -11844,11 +11891,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-rpc-engine-api"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+name = "reth-rpc-convert"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
- "alloy-eips 1.0.12",
+ "alloy-consensus 1.0.17",
+ "alloy-json-rpc 1.0.17",
+ "alloy-network",
+ "alloy-primitives 1.2.1",
+ "alloy-rpc-types-eth 1.0.17",
+ "jsonrpsee-types 0.25.1",
+ "reth-evm",
+ "reth-primitives-traits",
+ "revm-context 8.0.2",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "reth-rpc-engine-api"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
+dependencies = [
+ "alloy-eips 1.0.17",
  "alloy-primitives 1.2.1",
  "alloy-rpc-types-engine",
  "async-trait",
@@ -11875,19 +11939,20 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-api"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
- "alloy-consensus 1.0.12",
+ "alloy-consensus 1.0.17",
  "alloy-dyn-abi",
- "alloy-eips 1.0.12",
- "alloy-json-rpc 1.0.12",
+ "alloy-eips 1.0.17",
+ "alloy-evm",
+ "alloy-json-rpc 1.0.17",
  "alloy-network",
  "alloy-primitives 1.2.1",
  "alloy-rlp",
- "alloy-rpc-types-eth 1.0.12",
+ "alloy-rpc-types-eth 1.0.17",
  "alloy-rpc-types-mev",
- "alloy-serde 1.0.12",
+ "alloy-serde 1.0.17",
  "async-trait",
  "auto_impl",
  "dyn-clone",
@@ -11895,6 +11960,7 @@ dependencies = [
  "jsonrpsee 0.25.1",
  "jsonrpsee-types 0.25.1",
  "parking_lot",
+ "reth-chain-state",
  "reth-chainspec",
  "reth-errors",
  "reth-evm",
@@ -11903,28 +11969,29 @@ dependencies = [
  "reth-payload-builder",
  "reth-primitives-traits",
  "reth-revm",
+ "reth-rpc-convert",
  "reth-rpc-eth-types",
  "reth-rpc-server-types",
- "reth-rpc-types-compat",
  "reth-storage-api",
  "reth-tasks",
  "reth-transaction-pool",
  "reth-trie-common",
- "revm",
- "revm-inspectors",
+ "revm 27.0.2",
+ "revm-inspectors 0.26.5",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "reth-rpc-eth-types"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
- "alloy-consensus 1.0.12",
- "alloy-eips 1.0.12",
+ "alloy-consensus 1.0.17",
+ "alloy-eips 1.0.17",
+ "alloy-evm",
  "alloy-primitives 1.2.1",
- "alloy-rpc-types-eth 1.0.12",
+ "alloy-rpc-types-eth 1.0.17",
  "alloy-sol-types 1.2.1",
  "derive_more 2.0.1",
  "futures",
@@ -11942,14 +12009,14 @@ dependencies = [
  "reth-metrics",
  "reth-primitives-traits",
  "reth-revm",
+ "reth-rpc-convert",
  "reth-rpc-server-types",
- "reth-rpc-types-compat",
  "reth-storage-api",
  "reth-tasks",
  "reth-transaction-pool",
  "reth-trie",
- "revm",
- "revm-inspectors",
+ "revm 27.0.2",
+ "revm-inspectors 0.26.5",
  "schnellru",
  "serde",
  "thiserror 2.0.12",
@@ -11960,8 +12027,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-layer"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.3.1",
@@ -11974,10 +12041,10 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
- "alloy-eips 1.0.12",
+ "alloy-eips 1.0.17",
  "alloy-primitives 1.2.1",
  "alloy-rpc-types-engine",
  "jsonrpsee-core 0.25.1",
@@ -11989,31 +12056,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-rpc-types-compat"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
-dependencies = [
- "alloy-consensus 1.0.12",
- "alloy-network",
- "alloy-primitives 1.2.1",
- "alloy-rpc-types-eth 1.0.12",
- "jsonrpsee-types 0.25.1",
- "op-alloy-consensus",
- "op-alloy-rpc-types",
- "reth-optimism-primitives",
- "reth-primitives-traits",
- "reth-storage-api",
- "serde",
- "thiserror 2.0.12",
-]
-
-[[package]]
 name = "reth-stages"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
- "alloy-consensus 1.0.12",
- "alloy-eips 1.0.12",
+ "alloy-consensus 1.0.17",
+ "alloy-eips 1.0.17",
  "alloy-primitives 1.2.1",
  "bincode",
  "blake3",
@@ -12055,10 +12103,10 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-api"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
- "alloy-eips 1.0.12",
+ "alloy-eips 1.0.17",
  "alloy-primitives 1.2.1",
  "aquamarine",
  "auto_impl",
@@ -12082,8 +12130,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
  "alloy-primitives 1.2.1",
  "arbitrary",
@@ -12096,8 +12144,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
  "alloy-primitives 1.2.1",
  "parking_lot",
@@ -12116,8 +12164,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
  "alloy-primitives 1.2.1",
  "clap 4.5.40",
@@ -12128,11 +12176,11 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
- "alloy-consensus 1.0.12",
- "alloy-eips 1.0.12",
+ "alloy-consensus 1.0.17",
+ "alloy-eips 1.0.17",
  "alloy-primitives 1.2.1",
  "alloy-rpc-types-engine",
  "auto_impl",
@@ -12147,29 +12195,29 @@ dependencies = [
  "reth-storage-errors",
  "reth-trie-common",
  "reth-trie-db",
- "revm-database",
+ "revm-database 7.0.1",
 ]
 
 [[package]]
 name = "reth-storage-errors"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
- "alloy-eips 1.0.12",
+ "alloy-eips 1.0.17",
  "alloy-primitives 1.2.1",
  "alloy-rlp",
  "derive_more 2.0.1",
  "reth-primitives-traits",
  "reth-prune-types",
  "reth-static-file-types",
- "revm-database-interface",
+ "revm-database-interface 7.0.1",
  "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "reth-tasks"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -12186,8 +12234,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -12196,8 +12244,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
  "clap 4.5.40",
  "eyre",
@@ -12211,11 +12259,11 @@ dependencies = [
 
 [[package]]
 name = "reth-transaction-pool"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
- "alloy-consensus 1.0.12",
- "alloy-eips 1.0.12",
+ "alloy-consensus 1.0.17",
+ "alloy-eips 1.0.17",
  "alloy-primitives 1.2.1",
  "alloy-rlp",
  "aquamarine",
@@ -12235,8 +12283,8 @@ dependencies = [
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-tasks",
- "revm-interpreter",
- "revm-primitives",
+ "revm-interpreter 23.0.1",
+ "revm-primitives 20.0.0",
  "rustc-hash 2.1.1",
  "schnellru",
  "serde",
@@ -12249,14 +12297,14 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
- "alloy-consensus 1.0.12",
- "alloy-eips 1.0.12",
+ "alloy-consensus 1.0.17",
+ "alloy-eips 1.0.17",
  "alloy-primitives 1.2.1",
  "alloy-rlp",
- "alloy-trie 0.8.1",
+ "alloy-trie 0.9.0",
  "auto_impl",
  "itertools 0.14.0",
  "metrics",
@@ -12267,41 +12315,41 @@ dependencies = [
  "reth-storage-errors",
  "reth-trie-common",
  "reth-trie-sparse",
- "revm-database",
+ "revm-database 7.0.1",
  "tracing",
  "triehash",
 ]
 
 [[package]]
 name = "reth-trie-common"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
- "alloy-consensus 1.0.12",
+ "alloy-consensus 1.0.17",
  "alloy-primitives 1.2.1",
  "alloy-rlp",
- "alloy-rpc-types-eth 1.0.12",
- "alloy-serde 1.0.12",
- "alloy-trie 0.8.1",
+ "alloy-rpc-types-eth 1.0.17",
+ "alloy-serde 1.0.17",
+ "alloy-trie 0.9.0",
  "arbitrary",
  "bytes",
  "derive_more 2.0.1",
  "hash-db",
  "itertools 0.14.0",
- "nybbles",
+ "nybbles 0.4.0",
  "plain_hasher",
  "rayon",
  "reth-codecs",
  "reth-primitives-traits",
- "revm-database",
+ "revm-database 7.0.1",
  "serde",
  "serde_with",
 ]
 
 [[package]]
 name = "reth-trie-db"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
  "alloy-primitives 1.2.1",
  "reth-db-api",
@@ -12313,8 +12361,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-parallel"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
  "alloy-primitives 1.2.1",
  "alloy-rlp",
@@ -12338,12 +12386,12 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
  "alloy-primitives 1.2.1",
  "alloy-rlp",
- "alloy-trie 0.8.1",
+ "alloy-trie 0.9.0",
  "auto_impl",
  "metrics",
  "reth-execution-errors",
@@ -12356,8 +12404,8 @@ dependencies = [
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?branch=fusaka%2Fdevnet2#601672e756e64c9d8d76f994e860908673847b56"
+version = "1.5.0"
+source = "git+file:///Users/vedabharath/ef-work/reth?branch=fusaka-devnet-2#fce4cc1c51df9bda7c4abf1079c83fa0b4935786"
 dependencies = [
  "zstd 0.13.3",
 ]
@@ -12365,116 +12413,234 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "24.0.1"
-source = "git+https://github.com/bluealloy/revm?branch=fusaka%2Fdevnet2#e8fb036fc6d9c2dcb6d67b4c319b827dc8b0a0d3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01d277408ff8d6f747665ad9e52150ab4caf8d5eaf0d787614cf84633c8337b4"
 dependencies = [
- "revm-bytecode",
- "revm-context",
- "revm-context-interface",
- "revm-database",
- "revm-database-interface",
- "revm-handler",
- "revm-inspector",
- "revm-interpreter",
- "revm-precompile",
- "revm-primitives",
- "revm-state",
+ "revm-bytecode 4.1.0",
+ "revm-context 5.0.1",
+ "revm-context-interface 5.0.0",
+ "revm-database 4.0.1",
+ "revm-database-interface 4.0.1",
+ "revm-handler 5.0.1",
+ "revm-inspector 5.0.1",
+ "revm-interpreter 20.0.0",
+ "revm-precompile 21.0.0",
+ "revm-primitives 19.2.0",
+ "revm-state 4.0.1",
+]
+
+[[package]]
+name = "revm"
+version = "27.0.2"
+source = "git+https://github.com/bluealloy/revm?branch=rakita%2Fcontract_size_limit#3184d8b8e9acccc9c4caf6823b32313a415672a1"
+dependencies = [
+ "revm-bytecode 6.0.1",
+ "revm-context 8.0.2",
+ "revm-context-interface 8.0.1",
+ "revm-database 7.0.1",
+ "revm-database-interface 7.0.1",
+ "revm-handler 8.0.2",
+ "revm-inspector 8.0.2",
+ "revm-interpreter 23.0.1",
+ "revm-precompile 24.0.0",
+ "revm-primitives 20.0.0",
+ "revm-state 7.0.1",
 ]
 
 [[package]]
 name = "revm-bytecode"
-version = "4.0.1"
-source = "git+https://github.com/bluealloy/revm?branch=fusaka%2Fdevnet2#e8fb036fc6d9c2dcb6d67b4c319b827dc8b0a0d3"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "942fe4724cf552fd28db6b0a2ca5b79e884d40dd8288a4027ed1e9090e0c6f49"
+dependencies = [
+ "bitvec",
+ "once_cell",
+ "revm-primitives 19.2.0",
+]
+
+[[package]]
+name = "revm-bytecode"
+version = "6.0.1"
+source = "git+https://github.com/bluealloy/revm?branch=rakita%2Fcontract_size_limit#3184d8b8e9acccc9c4caf6823b32313a415672a1"
 dependencies = [
  "bitvec",
  "once_cell",
  "phf 0.11.3",
- "revm-primitives",
+ "revm-primitives 20.0.0",
  "serde",
 ]
 
 [[package]]
 name = "revm-context"
 version = "5.0.1"
-source = "git+https://github.com/bluealloy/revm?branch=fusaka%2Fdevnet2#e8fb036fc6d9c2dcb6d67b4c319b827dc8b0a0d3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b01aad49e1233f94cebda48a4e5cef022f7c7ed29b4edf0d202b081af23435ef"
 dependencies = [
  "cfg-if",
  "derive-where",
- "revm-bytecode",
- "revm-context-interface",
- "revm-database-interface",
- "revm-primitives",
- "revm-state",
+ "revm-bytecode 4.1.0",
+ "revm-context-interface 5.0.0",
+ "revm-database-interface 4.0.1",
+ "revm-primitives 19.2.0",
+ "revm-state 4.0.1",
+]
+
+[[package]]
+name = "revm-context"
+version = "8.0.2"
+source = "git+https://github.com/bluealloy/revm?branch=rakita%2Fcontract_size_limit#3184d8b8e9acccc9c4caf6823b32313a415672a1"
+dependencies = [
+ "cfg-if",
+ "derive-where",
+ "revm-bytecode 6.0.1",
+ "revm-context-interface 8.0.1",
+ "revm-database-interface 7.0.1",
+ "revm-primitives 20.0.0",
+ "revm-state 7.0.1",
  "serde",
 ]
 
 [[package]]
 name = "revm-context-interface"
 version = "5.0.0"
-source = "git+https://github.com/bluealloy/revm?branch=fusaka%2Fdevnet2#e8fb036fc6d9c2dcb6d67b4c319b827dc8b0a0d3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b844f48a411e62c7dde0f757bf5cce49c85b86d6fc1d3b2722c07f2bec4c3ce"
 dependencies = [
  "alloy-eip2930 0.2.1",
  "alloy-eip7702 0.6.1",
  "auto_impl",
  "either",
- "revm-database-interface",
- "revm-primitives",
- "revm-state",
+ "revm-database-interface 4.0.1",
+ "revm-primitives 19.2.0",
+ "revm-state 4.0.1",
+]
+
+[[package]]
+name = "revm-context-interface"
+version = "8.0.1"
+source = "git+https://github.com/bluealloy/revm?branch=rakita%2Fcontract_size_limit#3184d8b8e9acccc9c4caf6823b32313a415672a1"
+dependencies = [
+ "alloy-eip2930 0.2.1",
+ "alloy-eip7702 0.6.1",
+ "auto_impl",
+ "either",
+ "revm-database-interface 7.0.1",
+ "revm-primitives 20.0.0",
+ "revm-state 7.0.1",
  "serde",
 ]
 
 [[package]]
 name = "revm-database"
 version = "4.0.1"
-source = "git+https://github.com/bluealloy/revm?branch=fusaka%2Fdevnet2#e8fb036fc6d9c2dcb6d67b4c319b827dc8b0a0d3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad3fbe34f6bb00a9c3155723b3718b9cb9f17066ba38f9eb101b678cd3626775"
 dependencies = [
- "alloy-eips 1.0.12",
- "revm-bytecode",
- "revm-database-interface",
- "revm-primitives",
- "revm-state",
+ "revm-bytecode 4.1.0",
+ "revm-database-interface 4.0.1",
+ "revm-primitives 19.2.0",
+ "revm-state 4.0.1",
+]
+
+[[package]]
+name = "revm-database"
+version = "7.0.1"
+source = "git+https://github.com/bluealloy/revm?branch=rakita%2Fcontract_size_limit#3184d8b8e9acccc9c4caf6823b32313a415672a1"
+dependencies = [
+ "alloy-eips 1.0.17",
+ "revm-bytecode 6.0.1",
+ "revm-database-interface 7.0.1",
+ "revm-primitives 20.0.0",
+ "revm-state 7.0.1",
  "serde",
 ]
 
 [[package]]
 name = "revm-database-interface"
 version = "4.0.1"
-source = "git+https://github.com/bluealloy/revm?branch=fusaka%2Fdevnet2#e8fb036fc6d9c2dcb6d67b4c319b827dc8b0a0d3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b8acd36784a6d95d5b9e1b7be3ce014f1e759abb59df1fa08396b30f71adc2a"
 dependencies = [
  "auto_impl",
- "revm-primitives",
- "revm-state",
+ "revm-primitives 19.2.0",
+ "revm-state 4.0.1",
+]
+
+[[package]]
+name = "revm-database-interface"
+version = "7.0.1"
+source = "git+https://github.com/bluealloy/revm?branch=rakita%2Fcontract_size_limit#3184d8b8e9acccc9c4caf6823b32313a415672a1"
+dependencies = [
+ "auto_impl",
+ "either",
+ "revm-primitives 20.0.0",
+ "revm-state 7.0.1",
  "serde",
 ]
 
 [[package]]
 name = "revm-handler"
 version = "5.0.1"
-source = "git+https://github.com/bluealloy/revm?branch=fusaka%2Fdevnet2#e8fb036fc6d9c2dcb6d67b4c319b827dc8b0a0d3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "481e8c3290ff4fa1c066592fdfeb2b172edfd14d12e6cade6f6f5588cad9359a"
 dependencies = [
  "auto_impl",
- "revm-bytecode",
- "revm-context",
- "revm-context-interface",
- "revm-database-interface",
- "revm-interpreter",
- "revm-precompile",
- "revm-primitives",
- "revm-state",
+ "revm-bytecode 4.1.0",
+ "revm-context 5.0.1",
+ "revm-context-interface 5.0.0",
+ "revm-database-interface 4.0.1",
+ "revm-interpreter 20.0.0",
+ "revm-precompile 21.0.0",
+ "revm-primitives 19.2.0",
+ "revm-state 4.0.1",
+]
+
+[[package]]
+name = "revm-handler"
+version = "8.0.2"
+source = "git+https://github.com/bluealloy/revm?branch=rakita%2Fcontract_size_limit#3184d8b8e9acccc9c4caf6823b32313a415672a1"
+dependencies = [
+ "auto_impl",
+ "derive-where",
+ "revm-bytecode 6.0.1",
+ "revm-context 8.0.2",
+ "revm-context-interface 8.0.1",
+ "revm-database-interface 7.0.1",
+ "revm-interpreter 23.0.1",
+ "revm-precompile 24.0.0",
+ "revm-primitives 20.0.0",
+ "revm-state 7.0.1",
  "serde",
 ]
 
 [[package]]
 name = "revm-inspector"
 version = "5.0.1"
-source = "git+https://github.com/bluealloy/revm?branch=fusaka%2Fdevnet2#e8fb036fc6d9c2dcb6d67b4c319b827dc8b0a0d3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc1167ef8937d8867888e63581d8ece729a72073d322119ef4627d813d99ecb"
 dependencies = [
  "auto_impl",
- "revm-context",
- "revm-database-interface",
- "revm-handler",
- "revm-interpreter",
- "revm-primitives",
- "revm-state",
+ "revm-context 5.0.1",
+ "revm-database-interface 4.0.1",
+ "revm-handler 5.0.1",
+ "revm-interpreter 20.0.0",
+ "revm-primitives 19.2.0",
+ "revm-state 4.0.1",
+]
+
+[[package]]
+name = "revm-inspector"
+version = "8.0.2"
+source = "git+https://github.com/bluealloy/revm?branch=rakita%2Fcontract_size_limit#3184d8b8e9acccc9c4caf6823b32313a415672a1"
+dependencies = [
+ "auto_impl",
+ "either",
+ "revm-context 8.0.2",
+ "revm-database-interface 7.0.1",
+ "revm-handler 8.0.2",
+ "revm-interpreter 23.0.1",
+ "revm-primitives 20.0.0",
+ "revm-state 7.0.1",
  "serde",
  "serde_json",
 ]
@@ -12486,14 +12652,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b50ef375dbacefecfdacf8f02afc31df98acc5d8859a6f2b24d121ff2a740a8"
 dependencies = [
  "alloy-primitives 1.2.1",
- "alloy-rpc-types-eth 1.0.12",
+ "alloy-rpc-types-eth 1.0.17",
+ "alloy-rpc-types-trace",
+ "alloy-sol-types 1.2.1",
+ "colorchoice",
+ "revm 24.0.1",
+ "serde_json",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "revm-inspectors"
+version = "0.26.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7b99a2332cf8eed9e9a22fffbf76dfadc99d2c45de6ae6431a1eb9f657dd97a"
+dependencies = [
+ "alloy-primitives 1.2.1",
+ "alloy-rpc-types-eth 1.0.17",
  "alloy-rpc-types-trace",
  "alloy-sol-types 1.2.1",
  "anstyle",
  "boa_engine",
  "boa_gc",
  "colorchoice",
- "revm",
+ "revm 27.0.2",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -12502,24 +12684,56 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "20.0.0"
-source = "git+https://github.com/bluealloy/revm?branch=fusaka%2Fdevnet2#e8fb036fc6d9c2dcb6d67b4c319b827dc8b0a0d3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5ee65e57375c6639b0f50555e92a4f1b2434349dd32f52e2176f5c711171697"
 dependencies = [
- "revm-bytecode",
- "revm-context-interface",
- "revm-primitives",
+ "revm-bytecode 4.1.0",
+ "revm-context-interface 5.0.0",
+ "revm-primitives 19.2.0",
+]
+
+[[package]]
+name = "revm-interpreter"
+version = "23.0.1"
+source = "git+https://github.com/bluealloy/revm?branch=rakita%2Fcontract_size_limit#3184d8b8e9acccc9c4caf6823b32313a415672a1"
+dependencies = [
+ "revm-bytecode 6.0.1",
+ "revm-context-interface 8.0.1",
+ "revm-primitives 20.0.0",
  "serde",
 ]
 
 [[package]]
 name = "revm-precompile"
 version = "21.0.0"
-source = "git+https://github.com/bluealloy/revm?branch=fusaka%2Fdevnet2#e8fb036fc6d9c2dcb6d67b4c319b827dc8b0a0d3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9311e735123d8d53a02af2aa81877bba185be7c141be7f931bb3d2f3af449c"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
  "ark-ec",
  "ark-ff 0.5.0",
  "ark-serialize 0.5.0",
+ "aurora-engine-modexp",
+ "cfg-if",
+ "k256 0.13.4",
+ "once_cell",
+ "revm-primitives 19.2.0",
+ "ripemd",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "revm-precompile"
+version = "24.0.0"
+source = "git+https://github.com/bluealloy/revm?branch=rakita%2Fcontract_size_limit#3184d8b8e9acccc9c4caf6823b32313a415672a1"
+dependencies = [
+ "ark-bls12-381",
+ "ark-bn254",
+ "ark-ec",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "arrayref",
  "aurora-engine-modexp",
  "blst",
  "c-kzg",
@@ -12528,16 +12742,27 @@ dependencies = [
  "libsecp256k1",
  "once_cell",
  "p256",
- "revm-primitives",
+ "revm-primitives 20.0.0",
  "ripemd",
- "secp256k1",
+ "rug",
+ "secp256k1 0.31.1",
  "sha2 0.10.9",
 ]
 
 [[package]]
 name = "revm-primitives"
-version = "19.1.0"
-source = "git+https://github.com/bluealloy/revm?branch=fusaka%2Fdevnet2#e8fb036fc6d9c2dcb6d67b4c319b827dc8b0a0d3"
+version = "19.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c1588093530ec4442461163be49c433c07a3235d1ca6f6799fef338dacc50d3"
+dependencies = [
+ "alloy-primitives 1.2.1",
+ "num_enum",
+]
+
+[[package]]
+name = "revm-primitives"
+version = "20.0.0"
+source = "git+https://github.com/bluealloy/revm?branch=rakita%2Fcontract_size_limit#3184d8b8e9acccc9c4caf6823b32313a415672a1"
 dependencies = [
  "alloy-primitives 1.2.1",
  "num_enum",
@@ -12547,11 +12772,22 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "4.0.1"
-source = "git+https://github.com/bluealloy/revm?branch=fusaka%2Fdevnet2#e8fb036fc6d9c2dcb6d67b4c319b827dc8b0a0d3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0040c61c30319254b34507383ba33d85f92949933adf6525a2cede05d165e1fa"
 dependencies = [
  "bitflags 2.9.1",
- "revm-bytecode",
- "revm-primitives",
+ "revm-bytecode 4.1.0",
+ "revm-primitives 19.2.0",
+]
+
+[[package]]
+name = "revm-state"
+version = "7.0.1"
+source = "git+https://github.com/bluealloy/revm?branch=rakita%2Fcontract_size_limit#3184d8b8e9acccc9c4caf6823b32313a415672a1"
+dependencies = [
+ "bitflags 2.9.1",
+ "revm-bytecode 6.0.1",
+ "revm-primitives 20.0.0",
  "serde",
 ]
 
@@ -12716,6 +12952,18 @@ dependencies = [
  "spki 0.7.3",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rug"
+version = "1.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4207e8d668e5b8eb574bda8322088ccd0d7782d3d03c7e8d562e82ed82bdcbc3"
+dependencies = [
+ "az",
+ "gmp-mpfr-sys",
+ "libc",
+ "libm",
 ]
 
 [[package]]
@@ -13168,8 +13416,19 @@ checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
 dependencies = [
  "bitcoin_hashes",
  "rand 0.8.5",
- "secp256k1-sys",
+ "secp256k1-sys 0.10.1",
  "serde",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c3c81b43dc2d8877c216a3fccf76677ee1ebccd429566d3e67447290d0c42b2"
+dependencies = [
+ "bitcoin_hashes",
+ "rand 0.9.1",
+ "secp256k1-sys 0.11.0",
 ]
 
 [[package]]
@@ -13177,6 +13436,15 @@ name = "secp256k1-sys"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb913707158fadaf0d8702c2db0e857de66eb003ccfdda5924b5f5ac98efb38"
 dependencies = [
  "cc",
 ]
@@ -14460,8 +14728,8 @@ name = "test-relay"
 version = "0.1.0"
 dependencies = [
  "ahash",
- "alloy-consensus 1.0.12",
- "alloy-json-rpc 1.0.12",
+ "alloy-consensus 1.0.17",
+ "alloy-json-rpc 1.0.17",
  "alloy-primitives 1.2.1",
  "alloy-provider",
  "clap 4.5.40",
@@ -16751,8 +17019,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "alloy-contract"
-version = "1.0.12"
-source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#c2584bebb3612351e529e5178f480016316c4120"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,51 +49,51 @@ codegen-units = 1
 incremental = false
 
 [workspace.dependencies]
-reth = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
-reth-chain-state = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
-reth-cli-util = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
-reth-db = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
-reth-db-common = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
-reth-errors = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
-reth-payload-builder = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
-reth-node-api = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
-reth-node-ethereum = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
-reth-trie = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
-reth-trie-parallel = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
-reth-basic-payload-builder = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
-reth-node-core = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
-reth-primitives = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
-reth-ethereum-primitives = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
-reth-primitives-traits = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
-reth-provider = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2", features = [
+reth = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-chain-state = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-cli-util = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-db = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-db-common = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-errors = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-payload-builder = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-node-api = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-node-ethereum = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-trie = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-trie-parallel = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-basic-payload-builder = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-node-core = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-primitives = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-ethereum-primitives = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-primitives-traits = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-provider = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix", features = [
     "test-utils",
 ] }
-reth-chainspec = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
-reth-evm = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
-reth-evm-ethereum = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
-reth-execution-errors = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
-reth-exex = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
-reth-metrics = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
-reth-trie-db = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
-reth-payload-primitives = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
-reth-transaction-pool = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
-reth-execution-types = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
-reth-revm = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
-reth-payload-builder-primitives = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
-reth-payload-util = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
-reth-rpc-layer = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
-reth-testing-utils = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
+reth-chainspec = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-evm = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-evm-ethereum = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-execution-errors = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-exex = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-metrics = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-trie-db = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-payload-primitives = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-transaction-pool = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-execution-types = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-revm = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-payload-builder-primitives = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-payload-util = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-rpc-layer = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-testing-utils = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
 
 # reth optimism
-reth-optimism-primitives = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
-reth-optimism-consensus = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
-reth-optimism-cli = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
-reth-optimism-forks = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
-reth-optimism-evm = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
-reth-optimism-node = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
-reth-optimism-payload-builder = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
-reth-optimism-chainspec = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
-reth-optimism-txpool = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
+reth-optimism-primitives = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-optimism-consensus = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-optimism-cli = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-optimism-forks = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-optimism-evm = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-optimism-node = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-optimism-payload-builder = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-optimism-chainspec = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-optimism-txpool = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
 
 
 # compatible with reth v1.4.8 dependencies
@@ -102,7 +102,7 @@ revm = { version = "27.0.1", features = [
     "secp256k1",
     "optional_balance_check",
 ], default-features = false }
-revm-inspectors = { version = "0.23.0", default-features = false }
+revm-inspectors = { version = "0.25.0", default-features = false }
 revm-state = { version = "7.0.0", default-features = false }
 
 ethereum_ssz_derive = "0.9.0"
@@ -112,24 +112,24 @@ alloy-primitives = { version = "1.2.0", default-features = false }
 alloy-rlp = "0.3.10"
 alloy-chains = "0.2.0"
 alloy-evm = { version = "0.13", default-features = false }
-alloy-provider = { version = "1.0.17", features = ["ipc", "pubsub"] }
-alloy-pubsub = { version = "1.0.17" }
-alloy-eips = { version = "1.0.17" }
-alloy-rpc-types = { version = "1.0.17" }
-alloy-json-rpc = { version = "1.0.17" }
-alloy-transport-http = { version = "1.0.17" }
-alloy-network = { version = "1.0.17" }
-alloy-network-primitives = { version = "1.0.17" }
-alloy-transport = { version = "1.0.17" }
-alloy-node-bindings = { version = "1.0.17" }
-alloy-consensus = { version = "1.0.17", features = ["kzg"] }
-alloy-serde = { version = "1.0.17" }
-alloy-rpc-types-beacon = { version = "1.0.17", features = ["ssz"] }
-alloy-rpc-types-engine = { version = "1.0.17", features = ["ssz"] }
-alloy-rpc-types-eth = { version = "1.0.17" }
-alloy-signer-local = { version = "1.0.17" }
-alloy-rpc-client = { version = "1.0.17" }
-alloy-genesis = { version = "1.0.17" }
+alloy-provider = { version = "1.0.16", features = ["ipc", "pubsub"] }
+alloy-pubsub = { version = "1.0.16" }
+alloy-eips = { version = "1.0.16" }
+alloy-rpc-types = { version = "1.0.16" }
+alloy-json-rpc = { version = "1.0.16"  }
+alloy-transport-http = { version = "1.0.16"  }
+alloy-network = { version = "1.0.16"  }
+alloy-network-primitives = { version = "1.0.16"  }
+alloy-transport = { version = "1.0.16" }
+alloy-node-bindings = { version = "1.0.16"  }
+alloy-consensus = { version = "1.0.16" , features = ["kzg"] }
+alloy-serde = { version = "1.0.16"  }
+alloy-rpc-types-beacon = { version = "1.0.16" , features = ["ssz"] }
+alloy-rpc-types-engine = { version = "1.0.16" , features = ["ssz"] }
+alloy-rpc-types-eth = { version = "1.0.16"  }
+alloy-signer-local = { version = "1.0.16"  }
+alloy-rpc-client = { version = "1.0.16" }
+alloy-genesis = { version = "1.0.16"  }
 alloy-trie = { version = "0.9.0", default-features = false }
 
 async-trait = { version = "0.1.83" }
@@ -171,33 +171,33 @@ metrics_macros = { path = "crates/rbuilder/src/telemetry/metrics_macros"}
 
 
 [patch.crates-io]
-#alloy-consensus = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-#alloy-contract = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-#alloy-eips = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-#alloy-genesis = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-#alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-#alloy-network = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-#alloy-network-primitives = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-#alloy-provider = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-#alloy-pubsub = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-#alloy-rpc-client = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-#alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-#alloy-rpc-types-admin = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-#alloy-rpc-types-anvil = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-#alloy-rpc-types-beacon = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-#alloy-rpc-types-debug = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-#alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-#alloy-rpc-types-eth = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-#alloy-rpc-types-mev = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-#alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-#alloy-rpc-types-txpool = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-#alloy-serde = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-#alloy-signer = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-#alloy-signer-local = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-#alloy-transport = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-#alloy-transport-http = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-#alloy-transport-ipc = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-#alloy-transport-ws = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
+alloy-consensus = { git = "https://github.com/bharath-123/alloy", branch = "fusaka/devnet2" }
+alloy-contract = { git = "https://github.com/bharath-123/alloy", branch = "fusaka/devnet2" }
+alloy-eips = { git = "https://github.com/bharath-123/alloy", branch = "fusaka/devnet2" }
+alloy-genesis = { git = "https://github.com/bharath-123/alloy", branch = "fusaka/devnet2" }
+alloy-json-rpc = { git = "https://github.com/bharath-123/alloy", branch = "fusaka/devnet2" }
+alloy-network = { git = "https://github.com/bharath-123/alloy", branch = "fusaka/devnet2" }
+alloy-network-primitives = { git = "https://github.com/bharath-123/alloy", branch = "fusaka/devnet2" }
+alloy-provider = { git = "https://github.com/bharath-123/alloy", branch = "fusaka/devnet2" }
+alloy-pubsub = { git = "https://github.com/bharath-123/alloy", branch = "fusaka/devnet2" }
+alloy-rpc-client = { git = "https://github.com/bharath-123/alloy", branch = "fusaka/devnet2" }
+alloy-rpc-types = { git = "https://github.com/bharath-123/alloy", branch = "fusaka/devnet2" }
+alloy-rpc-types-admin = { git = "https://github.com/bharath-123/alloy", branch = "fusaka/devnet2" }
+alloy-rpc-types-anvil = { git = "https://github.com/bharath-123/alloy", branch = "fusaka/devnet2" }
+alloy-rpc-types-beacon = { git = "https://github.com/bharath-123/alloy", branch = "fusaka/devnet2" }
+alloy-rpc-types-debug = { git = "https://github.com/bharath-123/alloy", branch = "fusaka/devnet2" }
+alloy-rpc-types-engine = { git = "https://github.com/bharath-123/alloy", branch = "fusaka/devnet2" }
+alloy-rpc-types-eth = { git = "https://github.com/bharath-123/alloy", branch = "fusaka/devnet2" }
+alloy-rpc-types-mev = { git = "https://github.com/bharath-123/alloy", branch = "fusaka/devnet2" }
+alloy-rpc-types-trace = { git = "https://github.com/bharath-123/alloy", branch = "fusaka/devnet2" }
+alloy-rpc-types-txpool = { git = "https://github.com/bharath-123/alloy", branch = "fusaka/devnet2" }
+alloy-serde = { git = "https://github.com/bharath-123/alloy", branch = "fusaka/devnet2" }
+alloy-signer = { git = "https://github.com/bharath-123/alloy", branch = "fusaka/devnet2" }
+alloy-signer-local = { git = "https://github.com/bharath-123/alloy", branch = "fusaka/devnet2" }
+alloy-transport = { git = "https://github.com/bharath-123/alloy", branch = "fusaka/devnet2" }
+alloy-transport-http = { git = "https://github.com/bharath-123/alloy", branch = "fusaka/devnet2" }
+alloy-transport-ipc = { git = "https://github.com/bharath-123/alloy", branch = "fusaka/devnet2" }
+alloy-transport-ws = { git = "https://github.com/bharath-123/alloy", branch = "fusaka/devnet2" }
 
 alloy-evm = { git = "https://github.com/alloy-rs/evm", branch = "fusaka/devnet2"}
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,85 +49,88 @@ codegen-units = 1
 incremental = false
 
 [workspace.dependencies]
-reth = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka/devnet2" }
-reth-chain-state = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka/devnet2" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka/devnet2" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka/devnet2" }
-reth-db-common = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka/devnet2" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka/devnet2" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka/devnet2" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka/devnet2" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka/devnet2" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka/devnet2" }
-reth-trie-parallel = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka/devnet2" }
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka/devnet2" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka/devnet2" }
-reth-primitives = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka/devnet2" }
-reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka/devnet2" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka/devnet2", features = [
+reth = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
+reth-chain-state = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
+reth-cli-util = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
+reth-db = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
+reth-db-common = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
+reth-errors = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
+reth-payload-builder = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
+reth-node-api = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
+reth-node-ethereum = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
+reth-trie = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
+reth-trie-parallel = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
+reth-basic-payload-builder = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
+reth-node-core = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
+reth-primitives = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
+reth-ethereum-primitives = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
+reth-primitives-traits = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
+reth-provider = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2", features = [
     "test-utils",
 ] }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka/devnet2" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka/devnet2" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka/devnet2" }
-reth-execution-errors = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka/devnet2" }
-reth-exex = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka/devnet2" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka/devnet2" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka/devnet2" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka/devnet2" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka/devnet2" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka/devnet2" }
-reth-revm = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka/devnet2" }
-reth-payload-builder-primitives = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka/devnet2" }
-reth-payload-util = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka/devnet2" }
-reth-rpc-layer = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka/devnet2" }
-reth-testing-utils = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka/devnet2" }
+reth-chainspec = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
+reth-evm = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
+reth-evm-ethereum = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
+reth-execution-errors = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
+reth-exex = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
+reth-metrics = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
+reth-trie-db = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
+reth-payload-primitives = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
+reth-transaction-pool = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
+reth-execution-types = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
+reth-revm = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
+reth-payload-builder-primitives = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
+reth-payload-util = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
+reth-rpc-layer = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
+reth-testing-utils = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
 
 # reth optimism
-reth-optimism-primitives = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka/devnet2" }
-reth-optimism-consensus = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka/devnet2" }
-reth-optimism-cli = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka/devnet2" }
-reth-optimism-forks = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka/devnet2" }
-reth-optimism-evm = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka/devnet2" }
-reth-optimism-node = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka/devnet2" }
-reth-optimism-payload-builder = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka/devnet2" }
-reth-optimism-chainspec = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka/devnet2" }
-reth-optimism-txpool = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka/devnet2" }
+reth-optimism-primitives = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
+reth-optimism-consensus = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
+reth-optimism-cli = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
+reth-optimism-forks = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
+reth-optimism-evm = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
+reth-optimism-node = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
+reth-optimism-payload-builder = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
+reth-optimism-chainspec = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
+reth-optimism-txpool = { git = "file:///Users/vedabharath/ef-work/reth", branch = "fusaka-devnet-2" }
+
 
 # compatible with reth v1.4.8 dependencies
-revm = { version = "24.0.1", features = [
+revm = { version = "27.0.1", features = [
     "std",
     "secp256k1",
     "optional_balance_check",
 ], default-features = false }
 revm-inspectors = { version = "0.23.0", default-features = false }
+revm-state = { version = "7.0.0", default-features = false }
 
 ethereum_ssz_derive = "0.9.0"
 ethereum_ssz = "0.9.0"
 
-alloy-primitives = { version = "1.1.0", default-features = false }
+alloy-primitives = { version = "1.2.0", default-features = false }
 alloy-rlp = "0.3.10"
 alloy-chains = "0.2.0"
-alloy-evm = { version = "0.10", default-features = false }
-alloy-provider = { version = "1.0.9", features = ["ipc", "pubsub"] }
-alloy-pubsub = { version = "1.0.9" }
-alloy-eips = { version = "1.0.9" }
-alloy-rpc-types = { version = "1.0.9" }
-alloy-json-rpc = { version = "1.0.9" }
-alloy-transport-http = { version = "1.0.9" }
-alloy-network = { version = "1.0.9" }
-alloy-network-primitives = { version = "1.0.9" }
-alloy-transport = { version = "1.0.9" }
-alloy-node-bindings = { version = "1.0.9" }
-alloy-consensus = { version = "1.0.9", features = ["kzg"] }
-alloy-serde = { version = "1.0.9" }
-alloy-rpc-types-beacon = { version = "1.0.9", features = ["ssz"] }
-alloy-rpc-types-engine = { version = "1.0.9", features = ["ssz"] }
-alloy-rpc-types-eth = { version = "1.0.9" }
-alloy-signer-local = { version = "1.0.9" }
-alloy-rpc-client = { version = "1.0.9" }
-alloy-genesis = { version = "1.0.9" }
-alloy-trie = { version = "0.8.1" }
+alloy-evm = { version = "0.13", default-features = false }
+alloy-provider = { version = "1.0.17", features = ["ipc", "pubsub"] }
+alloy-pubsub = { version = "1.0.17" }
+alloy-eips = { version = "1.0.17" }
+alloy-rpc-types = { version = "1.0.17" }
+alloy-json-rpc = { version = "1.0.17" }
+alloy-transport-http = { version = "1.0.17" }
+alloy-network = { version = "1.0.17" }
+alloy-network-primitives = { version = "1.0.17" }
+alloy-transport = { version = "1.0.17" }
+alloy-node-bindings = { version = "1.0.17" }
+alloy-consensus = { version = "1.0.17", features = ["kzg"] }
+alloy-serde = { version = "1.0.17" }
+alloy-rpc-types-beacon = { version = "1.0.17", features = ["ssz"] }
+alloy-rpc-types-engine = { version = "1.0.17", features = ["ssz"] }
+alloy-rpc-types-eth = { version = "1.0.17" }
+alloy-signer-local = { version = "1.0.17" }
+alloy-rpc-client = { version = "1.0.17" }
+alloy-genesis = { version = "1.0.17" }
+alloy-trie = { version = "0.9.0", default-features = false }
 
 async-trait = { version = "0.1.83" }
 clap = { version = "4.4.3", features = ["derive", "env"] }
@@ -168,44 +171,46 @@ metrics_macros = { path = "crates/rbuilder/src/telemetry/metrics_macros"}
 
 
 [patch.crates-io]
-alloy-consensus = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-alloy-contract = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-alloy-eips = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-alloy-genesis = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-alloy-network = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-alloy-network-primitives = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-alloy-provider = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-alloy-pubsub = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-alloy-rpc-client = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-alloy-rpc-types-admin = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-alloy-rpc-types-anvil = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-alloy-rpc-types-beacon = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-alloy-rpc-types-debug = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-alloy-rpc-types-eth = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-alloy-rpc-types-mev = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-alloy-rpc-types-txpool = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-alloy-serde = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-alloy-signer = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-alloy-signer-local = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-alloy-transport = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-alloy-transport-http = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-alloy-transport-ipc = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-alloy-transport-ws = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
+#alloy-consensus = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
+#alloy-contract = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
+#alloy-eips = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
+#alloy-genesis = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
+#alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
+#alloy-network = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
+#alloy-network-primitives = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
+#alloy-provider = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
+#alloy-pubsub = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
+#alloy-rpc-client = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
+#alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
+#alloy-rpc-types-admin = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
+#alloy-rpc-types-anvil = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
+#alloy-rpc-types-beacon = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
+#alloy-rpc-types-debug = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
+#alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
+#alloy-rpc-types-eth = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
+#alloy-rpc-types-mev = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
+#alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
+#alloy-rpc-types-txpool = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
+#alloy-serde = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
+#alloy-signer = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
+#alloy-signer-local = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
+#alloy-transport = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
+#alloy-transport-http = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
+#alloy-transport-ipc = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
+#alloy-transport-ws = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
 
-revm = { git = "https://github.com/bluealloy/revm", branch = "fusaka/devnet2" }
-revm-bytecode = { git = "https://github.com/bluealloy/revm", branch = "fusaka/devnet2" }
-revm-database = { git = "https://github.com/bluealloy/revm", branch = "fusaka/devnet2" }
-revm-state = { git = "https://github.com/bluealloy/revm", branch = "fusaka/devnet2" }
-revm-handler = { git = "https://github.com/bluealloy/revm", branch = "fusaka/devnet2" }
-revm-primitives = { git = "https://github.com/bluealloy/revm", branch = "fusaka/devnet2" }
-revm-interpreter = { git = "https://github.com/bluealloy/revm", branch = "fusaka/devnet2" }
-revm-inspector = { git = "https://github.com/bluealloy/revm", branch = "fusaka/devnet2" }
-revm-context = { git = "https://github.com/bluealloy/revm", branch = "fusaka/devnet2" }
-revm-context-interface = { git = "https://github.com/bluealloy/revm", branch = "fusaka/devnet2" }
-revm-database-interface = { git = "https://github.com/bluealloy/revm", branch = "fusaka/devnet2" }
-revm-precompile = { git = "https://github.com/bluealloy/revm", branch = "fusaka/devnet2" }
-op-revm = { git = "https://github.com/bluealloy/revm", branch = "fusaka/devnet2" }
+alloy-evm = { git = "https://github.com/alloy-rs/evm", branch = "fusaka/devnet2"}
+
+revm = { git = "https://github.com/bluealloy/revm", branch = "rakita/contract_size_limit" }
+revm-bytecode = { git = "https://github.com/bluealloy/revm", branch = "rakita/contract_size_limit" }
+revm-database = { git = "https://github.com/bluealloy/revm", branch = "rakita/contract_size_limit" }
+revm-state = { git = "https://github.com/bluealloy/revm", branch = "rakita/contract_size_limit" }
+revm-handler = { git = "https://github.com/bluealloy/revm", branch = "rakita/contract_size_limit" }
+revm-primitives = { git = "https://github.com/bluealloy/revm", branch = "rakita/contract_size_limit" }
+revm-interpreter = { git = "https://github.com/bluealloy/revm", branch = "rakita/contract_size_limit" }
+revm-inspector = { git = "https://github.com/bluealloy/revm", branch = "rakita/contract_size_limit" }
+revm-context = { git = "https://github.com/bluealloy/revm", branch = "rakita/contract_size_limit" }
+revm-context-interface = { git = "https://github.com/bluealloy/revm", branch = "rakita/contract_size_limit" }
+revm-database-interface = { git = "https://github.com/bluealloy/revm", branch = "rakita/contract_size_limit" }
+revm-precompile = { git = "https://github.com/bluealloy/revm", branch = "rakita/contract_size_limit" }
+op-revm = { git = "https://github.com/bluealloy/revm", branch = "rakita/contract_size_limit" }

--- a/crates/eth-sparse-mpt/src/utils.rs
+++ b/crates/eth-sparse-mpt/src/utils.rs
@@ -41,7 +41,7 @@ pub fn concat_path(p1: &Nibbles, p2: &[u8]) -> Nibbles {
 
 pub fn strip_first_nibble_mut(p: &mut Nibbles) -> u8 {
     let nibble = p.get_byte_unchecked(0);
-    let mut vec = p.to_vec();
+    let mut vec = p.pack().to_vec();
     vec.remove(0);
     p.clear();
     p.extend_from_slice_unchecked(vec.as_slice());

--- a/crates/eth-sparse-mpt/src/utils.rs
+++ b/crates/eth-sparse-mpt/src/utils.rs
@@ -31,25 +31,29 @@ pub fn rlp_pointer(rlp_encode: Bytes) -> Bytes {
 }
 
 pub fn concat_path(p1: &Nibbles, p2: &[u8]) -> Nibbles {
-    let mut result = Nibbles::with_capacity(p1.len() + p2.len());
-    result.extend_from_slice_unchecked(p1);
-    result.extend_from_slice_unchecked(p2);
+    // let mut result = Nibbles::with_capacity(p1.len() + p2.len());
+    // result.extend_from_slice_unchecked(p1);
+    // result.extend_from_slice_unchecked(p2);
+    let p2_nibble = Nibbles::unpack(p2);
+    let result = p1.join(&p2_nibble);
     result
 }
 
 pub fn strip_first_nibble_mut(p: &mut Nibbles) -> u8 {
-    let nibble = p[0];
-    let vec = p.as_mut_vec_unchecked();
+    let nibble = p.get_byte_unchecked(0);
+    let mut vec = p.to_vec();
     vec.remove(0);
+    p.clear();
+    p.extend_from_slice_unchecked(vec.as_slice());
     nibble
 }
 
 #[inline]
 pub fn extract_prefix_and_suffix(p1: &Nibbles, p2: &Nibbles) -> (Nibbles, Nibbles, Nibbles) {
     let prefix_len = p1.common_prefix_length(p2);
-    let prefix = Nibbles::from_nibbles_unchecked(&p1[..prefix_len]);
-    let suffix1 = Nibbles::from_nibbles_unchecked(&p1[prefix_len..]);
-    let suffix2 = Nibbles::from_nibbles_unchecked(&p2[prefix_len..]);
+    let prefix = Nibbles::from_nibbles_unchecked(&p1.to_vec()[..prefix_len]);
+    let suffix1 = Nibbles::from_nibbles_unchecked(&p1.to_vec()[prefix_len..]);
+    let suffix2 = Nibbles::from_nibbles_unchecked(&p2.to_vec()[prefix_len..]);
 
     (prefix, suffix1, suffix2)
 }

--- a/crates/eth-sparse-mpt/src/v1/reth_sparse_trie/trie_fetcher/mod.rs
+++ b/crates/eth-sparse-mpt/src/v1/reth_sparse_trie/trie_fetcher/mod.rs
@@ -108,7 +108,11 @@ where
 }
 
 fn pad_path(mut path: Nibbles) -> B256 {
-    path.as_mut_vec_unchecked().resize(64, 0);
+    // path.to_vec().resize(64, 0);
+    let mut path_vec = path.to_vec();
+    path_vec.resize(64, 0);
+    path.clear();
+    path.extend_from_slice_unchecked(path_vec.as_slice());
     let mut res = B256::default();
     path.pack_to(res.as_mut_slice());
     res

--- a/crates/eth-sparse-mpt/src/v1/reth_sparse_trie/trie_fetcher/mod.rs
+++ b/crates/eth-sparse-mpt/src/v1/reth_sparse_trie/trie_fetcher/mod.rs
@@ -2,7 +2,7 @@ use std::time::Instant;
 
 use crate::utils::{hash_map_with_capacity, HashMap, HashSet};
 use alloy_primitives::map::HashSet as AlloyHashSet;
-use tracing::trace;
+use tracing::{info, trace};
 
 use alloy_primitives::{Bytes, B256};
 use alloy_trie::Nibbles;
@@ -109,10 +109,10 @@ where
 
 fn pad_path(mut path: Nibbles) -> B256 {
     // path.to_vec().resize(64, 0);
-    let mut path_vec = path.to_vec();
-    path_vec.resize(64, 0);
+    let mut path_vec = path.pack();
+    path_vec.to_vec().resize(64, 0);
     path.clear();
-    path.extend_from_slice_unchecked(path_vec.as_slice());
+    path.extend_from_slice(path_vec.as_slice());
     let mut res = B256::default();
     path.pack_to(res.as_mut_slice());
     res

--- a/crates/eth-sparse-mpt/src/v1/sparse_mpt/diff_trie/mod.rs
+++ b/crates/eth-sparse-mpt/src/v1/sparse_mpt/diff_trie/mod.rs
@@ -65,7 +65,7 @@ pub struct NodeCursor {
 
 impl NodeCursor {
     pub fn new(key: Nibbles, head: u64) -> Self {
-        let current_path = Nibbles::with_capacity(key.len());
+        let current_path = Nibbles::new();
         Self {
             current_node: head,
             current_path,
@@ -76,8 +76,11 @@ impl NodeCursor {
     pub fn step_into_extension(&mut self, ext: &DiffExtensionNode) {
         let len = ext.key().len();
         self.current_path
-            .extend_from_slice_unchecked(&self.path_left[..len]);
-        self.path_left.as_mut_vec_unchecked().drain(..len);
+            .extend_from_slice_unchecked(&self.path_left.to_vec()[..len]);
+        let mut path_left_vec = self.path_left.to_vec();
+        path_left_vec.drain(..len);
+        self.path_left.clear();
+        self.path_left.extend_from_slice(path_left_vec.as_slice());
         self.current_node = ext.child.ptr();
     }
 
@@ -333,9 +336,13 @@ impl DiffTrie {
                             .expect("other child must exist");
                         if branch.get_diff_child(other_child_nibble).is_none() {
                             let mut other_child_path = c.current_path.clone();
-                            if let Some(l) = other_child_path.as_mut_vec_unchecked().last_mut() {
+                            let mut other_child_path_vec = other_child_path.to_vec();
+                            if let Some(l) = other_child_path_vec.last_mut() {
                                 *l = other_child_nibble;
                             }
+                            other_child_path.clear();
+                            other_child_path
+                                .extend_from_slice_unchecked(other_child_path_vec.as_slice());
                             return Err(DeletionError::NodeNotFound(ErrSparseNodeNotFound {
                                 path: other_child_path,
                                 ptr: u64::MAX,
@@ -430,7 +437,8 @@ impl DiffTrie {
                             // we just replace extension node by merging its path into leaf with child_nibble
                             let mut new_leaf_key = ext_above.key().clone();
                             new_leaf_key.push(*child_nibble);
-                            new_leaf_key.extend_from_slice_unchecked(leaf_below.key());
+                            new_leaf_key
+                                .extend_from_slice_unchecked(leaf_below.key().to_vec().as_slice());
 
                             let mut new_leaf = leaf_below;
                             new_leaf.changed_key = Some(new_leaf_key);
@@ -443,7 +451,8 @@ impl DiffTrie {
                             // we merge two extension nodes into current node with child_nibble
                             let ext_key = ext_above.key_mut();
                             ext_key.push(*child_nibble);
-                            ext_key.extend_from_slice_unchecked(ext_below.key());
+                            ext_key
+                                .extend_from_slice_unchecked(ext_below.key().to_vec().as_slice());
 
                             ext_above.child = ext_below.child.clone();
                         }
@@ -469,10 +478,16 @@ impl DiffTrie {
                             DiffTrieNodeKind::Leaf(mut leaf_below),
                         ) => {
                             // merge missing nibble into the leaf
+                            // leaf_below
+                            //     .key_mut()
+                            //     .as_mut_vec_unchecked()
+                            //     .insert(0, *child_nibble);
+                            let mut leaf_below_vec = leaf_below.key_mut().to_vec();
+                            leaf_below_vec.insert(0, *child_nibble);
+                            leaf_below.key_mut().clear();
                             leaf_below
                                 .key_mut()
-                                .as_mut_vec_unchecked()
-                                .insert(0, *child_nibble);
+                                .extend_from_slice_unchecked(leaf_below_vec.as_slice());
 
                             let new_leaf_ptr = get_new_ptr(&mut self.ptrs);
                             let new_child = DiffTrieNode {
@@ -491,10 +506,16 @@ impl DiffTrie {
                             DiffTrieNodeKind::Extension(mut ext_below),
                         ) => {
                             // merge missing nibble into the extension
+                            // ext_below
+                            //     .key_mut()
+                            //     .as_mut_vec_unchecked()
+                            //     .insert(0, *child_nibble);
+                            let mut ext_below_vec = ext_below.key_mut().to_vec();
+                            ext_below_vec.insert(0, *child_nibble);
+                            ext_below.key_mut().clear();
                             ext_below
                                 .key_mut()
-                                .as_mut_vec_unchecked()
-                                .insert(0, *child_nibble);
+                                .extend_from_slice_unchecked(ext_below_vec.as_slice());
                             let new_child_ptr = get_new_ptr(&mut self.ptrs);
                             let new_child = DiffTrieNode {
                                 kind: DiffTrieNodeKind::Extension(ext_below),
@@ -563,13 +584,23 @@ impl DiffTrie {
                     .expect("orphaned child existence verif");
                 match &mut child_below.kind {
                     DiffTrieNodeKind::Leaf(leaf) => {
+                        // leaf.key_mut()
+                        //     .as_mut_vec_unchecked()
+                        //     .insert(0, child_nibble);
+                        let mut leaf_vec = leaf.key_mut().to_vec();
+                        leaf_vec.insert(0, child_nibble);
+                        leaf.key_mut().clear();
                         leaf.key_mut()
-                            .as_mut_vec_unchecked()
-                            .insert(0, child_nibble);
+                            .extend_from_slice_unchecked(leaf_vec.as_slice());
                         child_below.rlp_pointer = None;
                     }
                     DiffTrieNodeKind::Extension(ext) => {
-                        ext.key_mut().as_mut_vec_unchecked().insert(0, child_nibble);
+                        // ext.key_mut().as_mut_vec_unchecked().insert(0, child_nibble);
+                        let mut ext_vec = ext.key_mut().to_vec();
+                        ext_vec.insert(0, child_nibble);
+                        ext.key_mut().clear();
+                        ext.key_mut()
+                            .extend_from_slice_unchecked(ext_vec.as_slice());
                         child_below.rlp_pointer = None;
                     }
                     DiffTrieNodeKind::Branch(_) => {

--- a/crates/eth-sparse-mpt/src/v1/sparse_mpt/diff_trie/mod.rs
+++ b/crates/eth-sparse-mpt/src/v1/sparse_mpt/diff_trie/mod.rs
@@ -75,9 +75,10 @@ impl NodeCursor {
 
     pub fn step_into_extension(&mut self, ext: &DiffExtensionNode) {
         let len = ext.key().len();
+        let mut path_left_vec = self.path_left.pack().to_vec();
+
         self.current_path
-            .extend_from_slice_unchecked(&self.path_left.to_vec()[..len]);
-        let mut path_left_vec = self.path_left.to_vec();
+            .extend_from_slice_unchecked(&path_left_vec[..len]);
         path_left_vec.drain(..len);
         self.path_left.clear();
         self.path_left.extend_from_slice(path_left_vec.as_slice());
@@ -336,7 +337,7 @@ impl DiffTrie {
                             .expect("other child must exist");
                         if branch.get_diff_child(other_child_nibble).is_none() {
                             let mut other_child_path = c.current_path.clone();
-                            let mut other_child_path_vec = other_child_path.to_vec();
+                            let mut other_child_path_vec = other_child_path.pack().to_vec();
                             if let Some(l) = other_child_path_vec.last_mut() {
                                 *l = other_child_nibble;
                             }
@@ -438,7 +439,7 @@ impl DiffTrie {
                             let mut new_leaf_key = ext_above.key().clone();
                             new_leaf_key.push(*child_nibble);
                             new_leaf_key
-                                .extend_from_slice_unchecked(leaf_below.key().to_vec().as_slice());
+                                .extend_from_slice_unchecked(leaf_below.key().pack().as_slice());
 
                             let mut new_leaf = leaf_below;
                             new_leaf.changed_key = Some(new_leaf_key);
@@ -452,7 +453,7 @@ impl DiffTrie {
                             let ext_key = ext_above.key_mut();
                             ext_key.push(*child_nibble);
                             ext_key
-                                .extend_from_slice_unchecked(ext_below.key().to_vec().as_slice());
+                                .extend_from_slice_unchecked(ext_below.key().pack().as_slice());
 
                             ext_above.child = ext_below.child.clone();
                         }
@@ -482,7 +483,7 @@ impl DiffTrie {
                             //     .key_mut()
                             //     .as_mut_vec_unchecked()
                             //     .insert(0, *child_nibble);
-                            let mut leaf_below_vec = leaf_below.key_mut().to_vec();
+                            let mut leaf_below_vec = leaf_below.key_mut().pack().to_vec();
                             leaf_below_vec.insert(0, *child_nibble);
                             leaf_below.key_mut().clear();
                             leaf_below
@@ -510,7 +511,7 @@ impl DiffTrie {
                             //     .key_mut()
                             //     .as_mut_vec_unchecked()
                             //     .insert(0, *child_nibble);
-                            let mut ext_below_vec = ext_below.key_mut().to_vec();
+                            let mut ext_below_vec = ext_below.key_mut().pack().to_vec();
                             ext_below_vec.insert(0, *child_nibble);
                             ext_below.key_mut().clear();
                             ext_below
@@ -587,7 +588,7 @@ impl DiffTrie {
                         // leaf.key_mut()
                         //     .as_mut_vec_unchecked()
                         //     .insert(0, child_nibble);
-                        let mut leaf_vec = leaf.key_mut().to_vec();
+                        let mut leaf_vec = leaf.key_mut().pack().to_vec();
                         leaf_vec.insert(0, child_nibble);
                         leaf.key_mut().clear();
                         leaf.key_mut()
@@ -596,7 +597,7 @@ impl DiffTrie {
                     }
                     DiffTrieNodeKind::Extension(ext) => {
                         // ext.key_mut().as_mut_vec_unchecked().insert(0, child_nibble);
-                        let mut ext_vec = ext.key_mut().to_vec();
+                        let mut ext_vec = ext.key_mut().pack().to_vec();
                         ext_vec.insert(0, child_nibble);
                         ext.key_mut().clear();
                         ext.key_mut()

--- a/crates/eth-sparse-mpt/src/v1/sparse_mpt/fixed_trie.rs
+++ b/crates/eth-sparse-mpt/src/v1/sparse_mpt/fixed_trie.rs
@@ -286,8 +286,12 @@ impl FixedTrie {
                             parent_child_idx = None;
 
                             let len = node.key.len();
-                            current_path.extend_from_slice_unchecked(&path_left[..len]);
-                            path_left.as_mut_vec_unchecked().drain(..len);
+                            current_path.extend_from_slice_unchecked(&path_left.to_vec()[..len]);
+                            // path_left.as_mut_vec_unchecked().drain(..len);
+                            let mut path_left_vec = path_left.to_vec();
+                            path_left_vec.drain(..len);
+                            path_left.clear();
+                            path_left.extend_from_slice_unchecked(path_left_vec.as_slice());
 
                             if path_left.is_empty() {
                                 break;
@@ -456,10 +460,14 @@ impl FixedTrie {
                                         // we stepped into child above so the path is the path of current child and orphan child differs
                                         // only in last nibble
                                         let mut path = c.current_path.clone();
-                                        path.as_mut_vec_unchecked()
-                                            .last_mut()
-                                            .map(|n| *n = orphan_nibble)
-                                            .unwrap();
+                                        // path.as_mut_vec_unchecked()
+                                        //     .last_mut()
+                                        //     .map(|n| *n = orphan_nibble)
+                                        //     .unwrap();
+                                        let mut path_vec = path.to_vec();
+                                        path_vec.last_mut().map(|n| *n = orphan_nibble).unwrap();
+                                        path.clear();
+                                        path.extend_from_slice_unchecked(path_vec.as_slice());
                                         missing_nodes.push(path);
                                     }
                                 }

--- a/crates/eth-sparse-mpt/src/v2/fetch.rs
+++ b/crates/eth-sparse-mpt/src/v2/fetch.rs
@@ -140,7 +140,7 @@ impl MissingNodesFetcher {
 
 fn pad_path(mut path: Nibbles) -> B256 {
     // path.to_vec().resize(64, 0);
-    let mut path_vec = path.to_vec();
+    let mut path_vec = path.pack().to_vec();
     path_vec.resize(64, 0);
     path.clear();
     path.extend_from_slice_unchecked(path_vec.as_slice());

--- a/crates/eth-sparse-mpt/src/v2/fetch.rs
+++ b/crates/eth-sparse-mpt/src/v2/fetch.rs
@@ -139,7 +139,11 @@ impl MissingNodesFetcher {
 }
 
 fn pad_path(mut path: Nibbles) -> B256 {
-    path.as_mut_vec_unchecked().resize(64, 0);
+    // path.to_vec().resize(64, 0);
+    let mut path_vec = path.to_vec();
+    path_vec.resize(64, 0);
+    path.clear();
+    path.extend_from_slice_unchecked(path_vec.as_slice());
     let mut res = B256::default();
     path.pack_to(res.as_mut_slice());
     res

--- a/crates/eth-sparse-mpt/src/v2/trie/mod.rs
+++ b/crates/eth-sparse-mpt/src/v2/trie/mod.rs
@@ -187,7 +187,7 @@ impl Trie {
         nibbles_key: &Nibbles,
         insert_value: InsertValue<'_>,
     ) -> Result<Option<Range<usize>>, NodeNotFound> {
-        let ins_key = nibbles_key.as_slice();
+        let ins_key = nibbles_key;
 
         let mut current_node = 0;
         let mut path_walked = 0;
@@ -204,7 +204,7 @@ impl Trie {
                 DiffTrieNode::Branch { children } => {
                     let children = *children;
 
-                    let n = ins_key[path_walked] as usize;
+                    let n = ins_key.to_vec()[path_walked] as usize;
                     path_walked += 1;
                     if let Some(child_ptr) = self.branch_node_children[children][n] {
                         current_node = child_ptr
@@ -212,7 +212,7 @@ impl Trie {
                             .ok_or_else(|| NodeNotFound(nibbles_key.clone()))?;
                         continue;
                     } else {
-                        let new_leaf_key = self.insert_key(&ins_key[path_walked..]);
+                        let new_leaf_key = self.insert_key(&ins_key.to_vec()[path_walked..]);
                         let leaf_value = self.insert_value(insert_value);
                         let leaf_ptr = self.push_node(DiffTrieNode::Leaf {
                             key: new_leaf_key,
@@ -225,7 +225,7 @@ impl Trie {
                     let key = key.clone();
                     let next_node = *next_node;
 
-                    if ins_key[path_walked..].starts_with(&self.keys[key.clone()]) {
+                    if ins_key.to_vec()[path_walked..].starts_with(&self.keys[key.clone()]) {
                         path_walked += key.len();
                         current_node = next_node
                             .local_ptr()
@@ -233,8 +233,8 @@ impl Trie {
                         continue;
                     }
 
-                    let (prefix, n1, suff1, n2, suff2) =
-                        self.extract_prefix_and_suffix(&ins_key[path_walked..], key);
+                    let t = &ins_key.to_vec()[path_walked..];
+                    let (prefix, n1, suff1, n2, suff2) = self.extract_prefix_and_suffix(t, key);
 
                     let has_extension_node = !prefix.is_empty();
                     if has_extension_node {
@@ -280,7 +280,7 @@ impl Trie {
                     let key = key.clone();
                     let value = value.clone();
 
-                    if self.keys[key.clone()] == ins_key[path_walked..] {
+                    if self.keys[key.clone()] == ins_key.to_vec()[path_walked..] {
                         // update leaf in place
                         old_value = Some(value.clone());
                         let new_value = self.insert_value(insert_value);
@@ -291,8 +291,9 @@ impl Trie {
                         break;
                     }
 
-                    let (prefix, n1, suff1, n2, suff2) =
-                        self.extract_prefix_and_suffix(&ins_key[path_walked..], key);
+                    let t = &ins_key.to_vec()[path_walked..];
+
+                    let (prefix, n1, suff1, n2, suff2) = self.extract_prefix_and_suffix(t, key);
 
                     let has_extension_node = !prefix.is_empty();
                     if has_extension_node {
@@ -332,7 +333,7 @@ impl Trie {
                     self.branch_node_children[branch_children][n2 as usize] = Some(second_leaf_ptr);
                 }
                 DiffTrieNode::Null => {
-                    let new_leaf_key = self.insert_key(&ins_key[path_walked..]);
+                    let new_leaf_key = self.insert_key(&ins_key.to_vec()[path_walked..]);
                     let new_leaf_value = self.insert_value(insert_value);
                     self.nodes[current_node] = DiffTrieNode::Leaf {
                         key: new_leaf_key,
@@ -365,7 +366,7 @@ impl Trie {
         &mut self,
         nibbles_key: &Nibbles,
     ) -> Result<Range<usize>, DeletionError> {
-        let del_key = nibbles_key.as_slice();
+        let del_key = nibbles_key;
 
         let mut current_node = 0;
         let mut path_walked = 0;
@@ -389,7 +390,7 @@ impl Trie {
 
                     let children = *children;
 
-                    let n = del_key[path_walked];
+                    let n = del_key.to_vec()[path_walked];
                     self.walk_path.push((current_node, n));
                     path_walked += 1;
 
@@ -411,9 +412,10 @@ impl Trie {
                                 .unwrap();
                             let orphan_ptr = orphan_ptr.unwrap();
                             if orphan_ptr.is_remote() {
-                                let mut orphan_path = Nibbles::with_capacity(path_walked);
-                                orphan_path
-                                    .extend_from_slice_unchecked(&del_key[..(path_walked - 1)]);
+                                let mut orphan_path = Nibbles::new();
+                                orphan_path.extend_from_slice_unchecked(
+                                    &del_key.to_vec()[..(path_walked - 1)],
+                                );
                                 orphan_path.push_unchecked(orphan_nibble as u8);
                                 return Err(NodeNotFound(orphan_path).into());
                             }
@@ -427,7 +429,7 @@ impl Trie {
                     let key = key.clone();
                     let next_node = *next_node;
 
-                    if del_key[path_walked..].starts_with(&self.keys[key.clone()]) {
+                    if del_key.to_vec()[path_walked..].starts_with(&self.keys[key.clone()]) {
                         self.walk_path.push((current_node, 0));
                         path_walked += key.len();
                         current_node = next_node
@@ -439,7 +441,7 @@ impl Trie {
                     return Err(DeletionError::KeyNotFound);
                 }
                 DiffTrieNode::Leaf { key, value } => {
-                    if self.keys[key.clone()] == del_key[path_walked..] {
+                    if self.keys[key.clone()] == del_key.to_vec()[path_walked..] {
                         old_value = value.clone();
                         self.walk_path.push((current_node, 0));
                         break;
@@ -941,13 +943,13 @@ impl Trie {
                 }
                 ProofNode::Extension { key, child } => {
                     let key = &proof_store.keys_guard()[*key];
-                    let key = self.insert_key(key);
+                    let key = self.insert_key(key.to_vec().as_slice());
                     let next_node = NodePtr::Remote(*child);
                     self.push_node(DiffTrieNode::Extension { key, next_node });
                 }
                 ProofNode::Leaf { key, value } => {
                     let key = &proof_store.keys_guard()[*key];
-                    let key = self.insert_key(key);
+                    let key = self.insert_key(key.to_vec().as_slice());
                     let value = &proof_store.values_guard()[*value];
                     let value = self.copy_value(value);
                     self.push_node(DiffTrieNode::Leaf { key, value });
@@ -969,14 +971,14 @@ impl Trie {
             let node = self
                 .nodes
                 .get(current_node)
-                .ok_or_else(|| NodeNotFound::new(&path[..path_walked]))?;
+                .ok_or_else(|| NodeNotFound::new(&path.to_vec()[..path_walked]))?;
             match node {
                 DiffTrieNode::Branch { children } => {
                     let children = *children;
 
-                    let n = path[path_walked] as usize;
+                    let n = path.to_vec()[path_walked] as usize;
                     path_walked += 1;
-                    if path[path_walked..].is_empty() {
+                    if path.to_vec()[path_walked..].is_empty() {
                         parent_ptr = self.branch_node_children[children][n];
                         parent_nibble = n;
                         break;
@@ -984,26 +986,28 @@ impl Trie {
                     if let Some(child_ptr) = self.branch_node_children[children][n] {
                         current_node = child_ptr
                             .local_ptr()
-                            .ok_or_else(|| NodeNotFound::new(&path[..path_walked]))?;
+                            .ok_or_else(|| NodeNotFound::new(&path.to_vec()[..path_walked]))?;
                         continue;
                     } else {
-                        return Err(NodeNotFound::new(&path[..path_walked]));
+                        return Err(NodeNotFound::new(&path.to_vec()[..path_walked]));
                     }
                 }
                 DiffTrieNode::Extension { key, next_node } => {
                     let key = key.clone();
                     let next_node = *next_node;
 
-                    if path[path_walked..].starts_with(&self.keys[key.clone()]) {
+                    if path.to_vec()[path_walked..].starts_with(&self.keys[key.clone()]) {
                         path_walked += key.len();
 
-                        if path[path_walked..].is_empty() {
+                        if path.to_vec()[path_walked..].is_empty() {
                             parent_ptr = Some(next_node);
                             parent_nibble = 0;
                             break;
                         }
                         current_node = next_node.local_ptr().ok_or_else(|| {
-                            NodeNotFound(Nibbles::from_nibbles_unchecked(&path[..path_walked]))
+                            NodeNotFound(Nibbles::from_nibbles_unchecked(
+                                &path.to_vec()[..path_walked],
+                            ))
                         })?;
                         continue;
                     }
@@ -1027,14 +1031,14 @@ impl Trie {
         let new_node = match node {
             ProofNode::Leaf { key, value } => {
                 let key = &proof_store.keys_guard()[*key];
-                let key = self.insert_key(key);
+                let key = self.insert_key(key.to_vec().as_slice());
                 let value = &proof_store.values_guard()[*value];
                 let value = self.copy_value(value);
                 self.push_node(DiffTrieNode::Leaf { key, value })
             }
             ProofNode::Extension { key, child } => {
                 let key = &proof_store.keys_guard()[*key];
-                let key = self.insert_key(key);
+                let key = self.insert_key(key.to_vec().as_slice());
                 let next_node = NodePtr::Remote(*child);
                 self.push_node(DiffTrieNode::Extension { key, next_node })
             }

--- a/crates/eth-sparse-mpt/src/v2/trie/mod.rs
+++ b/crates/eth-sparse-mpt/src/v2/trie/mod.rs
@@ -414,7 +414,7 @@ impl Trie {
                             if orphan_ptr.is_remote() {
                                 let mut orphan_path = Nibbles::new();
                                 orphan_path.extend_from_slice_unchecked(
-                                    &del_key.to_vec()[..(path_walked - 1)],
+                                    &del_key.pack().to_vec()[..(path_walked - 1)],
                                 );
                                 orphan_path.push_unchecked(orphan_nibble as u8);
                                 return Err(NodeNotFound(orphan_path).into());

--- a/crates/rbuilder/Cargo.toml
+++ b/crates/rbuilder/Cargo.toml
@@ -28,6 +28,7 @@ reth-trie-parallel.workspace = true
 reth-node-api.workspace = true
 reth-node-core.workspace = true
 reth-primitives.workspace = true
+reth-ethereum-primitives.workspace = true
 reth-primitives-traits.workspace = true
 reth-provider.workspace = true
 reth-chainspec.workspace = true

--- a/crates/rbuilder/src/building/builders/block_building_helper.rs
+++ b/crates/rbuilder/src/building/builders/block_building_helper.rs
@@ -258,7 +258,7 @@ impl BlockBuildingHelperFromProvider {
         );
 
         trace!(
-            block = building_ctx.evm_env.block_env.number,
+            block = building_ctx.evm_env.block_env.number.to_string(),
             build_time_mus = built_block_trace.fill_time.as_micros(),
             finalize_time_mus = built_block_trace.finalize_time.as_micros(),
             root_hash_time_mus = built_block_trace.root_hash_time.as_micros(),

--- a/crates/rbuilder/src/building/builders/mod.rs
+++ b/crates/rbuilder/src/building/builders/mod.rs
@@ -16,11 +16,11 @@ use crate::{
 };
 use ahash::HashSet;
 use alloy_eips::eip4844::BlobTransactionSidecar;
+use alloy_eips::eip7594::BlobTransactionSidecarVariant;
 use alloy_primitives::{Address, Bytes};
 use block_building_helper::BiddableUnfinishedBlock;
 use reth::primitives::SealedBlock;
 use std::{fmt::Debug, sync::Arc};
-use alloy_eips::eip7594::BlobTransactionSidecarVariant;
 use tokio::sync::{
     broadcast,
     broadcast::error::{RecvError, TryRecvError},

--- a/crates/rbuilder/src/building/builders/mod.rs
+++ b/crates/rbuilder/src/building/builders/mod.rs
@@ -20,6 +20,7 @@ use alloy_primitives::{Address, Bytes};
 use block_building_helper::BiddableUnfinishedBlock;
 use reth::primitives::SealedBlock;
 use std::{fmt::Debug, sync::Arc};
+use alloy_eips::eip7594::BlobTransactionSidecarVariant;
 use tokio::sync::{
     broadcast,
     broadcast::error::{RecvError, TryRecvError},
@@ -35,7 +36,7 @@ pub struct Block {
     pub trace: BuiltBlockTrace,
     pub sealed_block: SealedBlock,
     /// Sidecars for the txs included in SealedBlock
-    pub txs_blobs_sidecars: Vec<Arc<BlobTransactionSidecar>>,
+    pub txs_blobs_sidecars: Vec<Arc<BlobTransactionSidecarVariant>>,
     /// The Pectra execution requests for this bid.
     pub execution_requests: Vec<Bytes>,
     pub builder_name: String,

--- a/crates/rbuilder/src/building/builders/ordering_builder.rs
+++ b/crates/rbuilder/src/building/builders/ordering_builder.rs
@@ -20,6 +20,7 @@ use crate::{
     utils::NonceCache,
 };
 use ahash::{HashMap, HashSet};
+use alloy_primitives::U256;
 use derivative::Derivative;
 use reth_provider::StateProvider;
 use serde::Deserialize;
@@ -161,9 +162,12 @@ where
     P: StateProviderFactory + Clone + 'static,
 {
     let use_suggested_fee_recipient_as_coinbase = ordering_config.coinbase_payment;
-    let state_provider = input
-        .provider
-        .history_by_block_number(input.ctx.evm_env.block_env.number - 1)?;
+    let state_provider = input.provider.history_by_block_number(
+        (input.ctx.evm_env.block_env.number - U256::from(1))
+            .to_string()
+            .parse::<u64>()
+            .unwrap(),
+    )?; // TODO - bharath: U256 -> u64 conversion which is not desirable
     let block_orders =
         block_orders_from_sim_orders::<OrderPriorityType>(input.sim_orders, &state_provider)?;
     let mut local_ctx = ThreadBlockBuildingContext::default();

--- a/crates/rbuilder/src/building/evm.rs
+++ b/crates/rbuilder/src/building/evm.rs
@@ -1,4 +1,5 @@
 use crate::building::precompile_cache::{PrecompileCache, WrappedPrecompile};
+use alloy_evm::Database;
 use parking_lot::Mutex;
 use reth_evm::{
     eth::EthEvmContext, EthEvm, EthEvmFactory, Evm, EvmEnv, EvmFactory as RethEvmFactory,
@@ -12,7 +13,7 @@ use revm::{
     inspector::NoOpInspector,
     interpreter::interpreter::EthInterpreter,
     primitives::hardfork::SpecId,
-    Database, Inspector,
+    Inspector,
 };
 use std::sync::Arc;
 

--- a/crates/rbuilder/src/building/evm_inspector.rs
+++ b/crates/rbuilder/src/building/evm_inspector.rs
@@ -289,13 +289,14 @@ where
     CTX: ContextTr<Journal: JournalExt>,
     UsedStateEVMInspector<'a>: Inspector<CTX>,
 {
-    #[inline]
-    fn step(&mut self, interp: &mut Interpreter, context: &mut CTX) {
-        self.access_list_inspector.step(interp, context);
-        if let Some(used_state_inspector) = &mut self.used_state_inspector {
-            used_state_inspector.step(interp, context);
-        }
-    }
+    // TODO - looks like the step method has been removed from access_list_inspector? Debug this
+    // #[inline]
+    // fn step(&mut self, interp: &mut Interpreter, context: &mut CTX) {
+    //     self.access_list_inspector.step(interp, context);
+    //     if let Some(used_state_inspector) = &mut self.used_state_inspector {
+    //         used_state_inspector.step(interp, context);
+    //     }
+    // }
 
     #[inline]
     fn call(&mut self, context: &mut CTX, inputs: &mut CallInputs) -> Option<CallOutcome> {

--- a/crates/rbuilder/src/building/mod.rs
+++ b/crates/rbuilder/src/building/mod.rs
@@ -16,6 +16,7 @@ use crate::{
     },
 };
 use alloy_consensus::{Header, EMPTY_OMMER_ROOT_HASH};
+use alloy_eips::eip7594::BlobTransactionSidecarVariant;
 use alloy_eips::{
     eip1559::{calculate_block_gas_limit, ETHEREUM_BLOCK_GAS_LIMIT_30M},
     eip4844::BlobTransactionSidecar,
@@ -58,7 +59,6 @@ use std::{
     sync::Arc,
     time::{Duration, Instant},
 };
-use alloy_eips::eip7594::BlobTransactionSidecarVariant;
 use thiserror::Error;
 use time::OffsetDateTime;
 use tracing::{error, trace};
@@ -237,15 +237,16 @@ impl BlockBuildingContext {
             if chain_spec.is_cancun_active_at_timestamp(onchain_block.header.timestamp) {
                 Some(BlobExcessGasAndPrice::new(
                     onchain_block.header.excess_blob_gas.unwrap_or_default(),
-                    chain_spec.is_prague_active_at_timestamp(onchain_block.header.timestamp),
+                    // TODO - bharath
+                    100,
                 ))
             } else {
                 None
             };
         let block_env = BlockEnv {
-            number: block_number,
+            number: U256::from(block_number),
             beneficiary,
-            timestamp: onchain_block.header.timestamp,
+            timestamp: U256::from(onchain_block.header.timestamp),
             difficulty: onchain_block.header.difficulty,
             prevrandao: Some(onchain_block.header.mix_hash),
             basefee: onchain_block
@@ -338,7 +339,12 @@ impl BlockBuildingContext {
     }
 
     pub fn block(&self) -> u64 {
-        self.evm_env.block_env.number
+        self.evm_env
+            .block_env
+            .number
+            .to_string()
+            .parse::<u64>()
+            .unwrap()
     }
 
     pub fn coinbase_is_suggested_fee_recipient(&self) -> bool {
@@ -773,8 +779,12 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
         let state_root = {
             let (bundle, _) = state.into_parts();
             // we use execution outcome here only for interface compatibility, its just a wrapper around bundle
-            let execution_outcome =
-                ExecutionOutcome::new(bundle, Vec::new(), block_number, Vec::new());
+            let execution_outcome = ExecutionOutcome::new(
+                bundle,
+                Vec::new(),
+                block_number.to_string().parse::<u64>().unwrap(),
+                Vec::new(),
+            ); // TODO - we need to convert from U256 to u64 which is not a good idea to do, we need to use U256 everywhere
             ctx.root_hasher.state_root(&execution_outcome, local_ctx)?
         };
         let root_hash_time = step_start.elapsed();
@@ -822,7 +832,10 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
                 }
             }
             (ctx.excess_blob_gas, Some(self.blob_gas_used))
-        } else if ctx.chain_spec.is_osaka_active_at_timestamp(ctx.attributes.timestamp) {
+        } else if ctx
+            .chain_spec
+            .is_osaka_active_at_timestamp(ctx.attributes.timestamp)
+        {
             for tx_with_blob in self.executed_tx_infos.iter().map(|info| &info.tx) {
                 let eip7594_sidecar = tx_with_blob.blobs_sidecar.as_eip7594();
 
@@ -853,7 +866,7 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
             mix_hash: ctx.attributes.prev_randao,
             nonce: BEACON_NONCE.into(),
             base_fee_per_gas: Some(ctx.evm_env.block_env.basefee),
-            number: block_number,
+            number: block_number.to_string().parse::<u64>().unwrap(),
             gas_limit: ctx.evm_env.block_env.gas_limit,
             difficulty: U256::ZERO,
             gas_used: self.gas_used,

--- a/crates/rbuilder/src/building/mod.rs
+++ b/crates/rbuilder/src/building/mod.rs
@@ -237,8 +237,7 @@ impl BlockBuildingContext {
             if chain_spec.is_cancun_active_at_timestamp(onchain_block.header.timestamp) {
                 Some(BlobExcessGasAndPrice::new(
                     onchain_block.header.excess_blob_gas.unwrap_or_default(),
-                    // TODO - bharath
-                    100,
+                    5007716,
                 ))
             } else {
                 None

--- a/crates/rbuilder/src/building/mod.rs
+++ b/crates/rbuilder/src/building/mod.rs
@@ -58,6 +58,7 @@ use std::{
     sync::Arc,
     time::{Duration, Instant},
 };
+use alloy_eips::eip7594::BlobTransactionSidecarVariant;
 use thiserror::Error;
 use time::OffsetDateTime;
 use tracing::{error, trace};
@@ -502,7 +503,7 @@ impl ExecutionError {
 pub struct FinalizeResult {
     pub sealed_block: SealedBlock,
     // sidecars for all txs in SealedBlock
-    pub txs_blob_sidecars: Vec<Arc<BlobTransactionSidecar>>,
+    pub txs_blob_sidecars: Vec<Arc<BlobTransactionSidecarVariant>>,
     /// The Pectra execution requests for this bid.
     pub execution_requests: Vec<Bytes>,
 
@@ -812,8 +813,23 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
             .is_cancun_active_at_timestamp(ctx.attributes.timestamp)
         {
             for tx_with_blob in self.executed_tx_infos.iter().map(|info| &info.tx) {
-                if !tx_with_blob.blobs_sidecar.blobs.is_empty() {
-                    txs_blob_sidecars.push(tx_with_blob.blobs_sidecar.clone());
+                let eip4844_sidecar = tx_with_blob.blobs_sidecar.as_eip4844();
+
+                if eip4844_sidecar.is_some() {
+                    if !eip4844_sidecar.unwrap().blobs.is_empty() {
+                        txs_blob_sidecars.push(tx_with_blob.blobs_sidecar.clone());
+                    }
+                }
+            }
+            (ctx.excess_blob_gas, Some(self.blob_gas_used))
+        } else if ctx.chain_spec.is_osaka_active_at_timestamp(ctx.attributes.timestamp) {
+            for tx_with_blob in self.executed_tx_infos.iter().map(|info| &info.tx) {
+                let eip7594_sidecar = tx_with_blob.blobs_sidecar.as_eip7594();
+
+                if eip7594_sidecar.is_some() {
+                    if !eip7594_sidecar.unwrap().blobs.is_empty() {
+                        txs_blob_sidecars.push(tx_with_blob.blobs_sidecar.clone());
+                    }
                 }
             }
             (ctx.excess_blob_gas, Some(self.blob_gas_used))

--- a/crates/rbuilder/src/building/order_commit.rs
+++ b/crates/rbuilder/src/building/order_commit.rs
@@ -34,6 +34,7 @@ use revm::{
     Database, DatabaseCommit,
 };
 use std::{collections::HashMap, sync::Arc};
+use alloy_eips::eip7594::BlobTransactionSidecarVariant;
 use thiserror::Error;
 
 #[derive(Clone)]
@@ -424,7 +425,12 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
     ) -> Result<Result<TransactionOk, TransactionErr>, CriticalCommitOrderError> {
         let coinbase_balance_before = I256::try_from(self.coinbase_balance()?)?;
         // Use blobs.len() instead of checking for tx type just in case in the future some other new txs have blobs
-        let blob_gas_used = tx_with_blobs.blobs_sidecar.blobs.len() as u64 * DATA_GAS_PER_BLOB;
+        // let blob_gas_used = tx_with_blobs.blobs_sidecar.blobs.len() as u64 * DATA_GAS_PER_BLOB;
+        let blob_gas_used = match tx_with_blobs.blobs_sidecar.as_ref() {
+            BlobTransactionSidecarVariant::Eip4844(eip4844_sidecar) => eip4844_sidecar.blobs.len() as u64 * DATA_GAS_PER_BLOB,
+            BlobTransactionSidecarVariant::Eip7594(eip7594_sidecar) => eip7594_sidecar.blobs.len() as u64 * DATA_GAS_PER_BLOB
+        };
+
         if cumulative_blob_gas_used + blob_gas_used > self.ctx.max_blob_gas_per_block() {
             return Ok(Err(TransactionErr::BlobGasLeft));
         }

--- a/crates/rbuilder/src/building/order_commit.rs
+++ b/crates/rbuilder/src/building/order_commit.rs
@@ -20,6 +20,8 @@ use crate::{
 use ahash::HashSet;
 use alloy_consensus::{constants::KECCAK_EMPTY, Transaction};
 use alloy_eips::eip4844::DATA_GAS_PER_BLOB;
+use alloy_eips::eip7594::BlobTransactionSidecarVariant;
+use alloy_evm::Database;
 use alloy_primitives::{Address, B256, I256, U256};
 use itertools::Itertools;
 use reth::revm::database::StateProviderDatabase;
@@ -31,10 +33,9 @@ use revm::{
     context::result::{ExecutionResult, ResultAndState},
     context_interface::result::{EVMError, InvalidTransaction},
     database::{states::bundle_state::BundleRetention, BundleState, State},
-    Database, DatabaseCommit,
+    Database as _, DatabaseCommit,
 };
 use std::{collections::HashMap, sync::Arc};
-use alloy_eips::eip7594::BlobTransactionSidecarVariant;
 use thiserror::Error;
 
 #[derive(Clone)]
@@ -243,7 +244,7 @@ pub enum BundleErr {
         "Trying to commit bundle for incorrect block, block: {block}, target_blocks: {target_block}-{target_max_block}"
     )]
     TargetBlockIncorrect {
-        block: u64,
+        block: U256,
         target_block: u64,
         target_max_block: u64,
     },
@@ -270,7 +271,7 @@ pub enum BundleErr {
     #[error("Incorrect refundable element: {0}")]
     IncorrectRefundableElement(usize),
     #[error("Incorrect timestamp, min: {min}, max: {max}, block: {block}")]
-    IncorrectTimestamp { min: u64, max: u64, block: u64 },
+    IncorrectTimestamp { min: u64, max: u64, block: U256 },
     #[error("Mev-share without signer")]
     NoSigner,
 }
@@ -427,8 +428,12 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
         // Use blobs.len() instead of checking for tx type just in case in the future some other new txs have blobs
         // let blob_gas_used = tx_with_blobs.blobs_sidecar.blobs.len() as u64 * DATA_GAS_PER_BLOB;
         let blob_gas_used = match tx_with_blobs.blobs_sidecar.as_ref() {
-            BlobTransactionSidecarVariant::Eip4844(eip4844_sidecar) => eip4844_sidecar.blobs.len() as u64 * DATA_GAS_PER_BLOB,
-            BlobTransactionSidecarVariant::Eip7594(eip7594_sidecar) => eip7594_sidecar.blobs.len() as u64 * DATA_GAS_PER_BLOB
+            BlobTransactionSidecarVariant::Eip4844(eip4844_sidecar) => {
+                eip4844_sidecar.blobs.len() as u64 * DATA_GAS_PER_BLOB
+            }
+            BlobTransactionSidecarVariant::Eip7594(eip7594_sidecar) => {
+                eip7594_sidecar.blobs.len() as u64 * DATA_GAS_PER_BLOB
+            }
         };
 
         if cumulative_blob_gas_used + blob_gas_used > self.ctx.max_blob_gas_per_block() {
@@ -585,7 +590,7 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
         let current_block = self.ctx.evm_env.block_env.number;
         // None is good for any block
         if let Some(block) = bundle.block {
-            if block != current_block {
+            if U256::from(block) != current_block {
                 return Ok(Err(BundleErr::TargetBlockIncorrect {
                     block: current_block,
                     target_block: block,
@@ -599,11 +604,11 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
             bundle.max_timestamp.unwrap_or(u64::MAX),
             self.ctx.evm_env.block_env.timestamp,
         );
-        if !(min_ts <= block_ts && block_ts <= max_ts) {
+        if !(U256::from(min_ts) <= block_ts && block_ts <= U256::from(max_ts)) {
             return Ok(Err(BundleErr::IncorrectTimestamp {
                 min: min_ts,
                 max: max_ts,
-                block: block_ts,
+                block: U256::from(block_ts),
             }));
         }
 
@@ -816,7 +821,9 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
         allow_tx_skip: bool,
     ) -> Result<Result<BundleOk, BundleErr>, CriticalCommitOrderError> {
         let current_block = self.ctx.evm_env.block_env.number;
-        if !(bundle.block <= current_block && current_block <= bundle.max_block) {
+        if !(U256::from(bundle.block) <= current_block
+            && current_block <= U256::from(bundle.max_block))
+        {
             return Ok(Err(BundleErr::TargetBlockIncorrect {
                 block: current_block,
                 target_block: bundle.block,

--- a/crates/rbuilder/src/building/testing/bundle_tests/mod.rs
+++ b/crates/rbuilder/src/building/testing/bundle_tests/mod.rs
@@ -1,9 +1,5 @@
 pub mod setup;
 
-use alloy_primitives::{B256, U256};
-use itertools::Itertools;
-use std::collections::HashSet;
-
 use crate::{
     building::{
         testing::bundle_tests::setup::NonceValue, BuiltBlockTrace, BundleErr, OrderErr,
@@ -12,6 +8,10 @@ use crate::{
     primitives::{Bundle, BundleRefund, Order, OrderId, Refund, RefundConfig, TxRevertBehavior},
     utils::{constants::BASE_TX_GAS, int_percentage},
 };
+use alloy_primitives::{B256, U256};
+use itertools::Itertools;
+use sha2::digest::consts::U25;
+use std::collections::HashSet;
 
 use self::setup::TestSetup;
 
@@ -96,10 +96,12 @@ fn test_target_block() -> eyre::Result<()> {
 
         test_setup.begin_bundle_order(NEXT_BUILT_BLOCK_NUMBER);
         test_setup.add_dummy_tx_0_1_no_rev()?;
+        let built_block_number_u256 = U256::from(BUILT_BLOCK_NUMBER);
+
         commit_order_err_matches!(
             test_setup,
             OrderErr::Bundle(BundleErr::TargetBlockIncorrect {
-                block: BUILT_BLOCK_NUMBER,
+                block: built_block_number_u256,
                 target_block: NEXT_BUILT_BLOCK_NUMBER,
                 target_max_block: NEXT_BUILT_BLOCK_NUMBER
             })
@@ -110,7 +112,7 @@ fn test_target_block() -> eyre::Result<()> {
         commit_order_err_matches!(
             test_setup,
             OrderErr::Bundle(BundleErr::TargetBlockIncorrect {
-                block: BUILT_BLOCK_NUMBER,
+                block: built_block_number_u256,
                 target_block: PREV_BUILT_BLOCK_NUMBER,
                 target_max_block: PREV_BUILT_BLOCK_NUMBER
             })
@@ -134,10 +136,12 @@ fn test_target_block() -> eyre::Result<()> {
 
         test_setup.begin_share_bundle_order(PREV_PREV_BUILT_BLOCK_NUMBER, PREV_BUILT_BLOCK_NUMBER);
         test_setup.add_dummy_tx_0_1_no_rev()?;
+        let built_block_number_u256 = U256::from(BUILT_BLOCK_NUMBER);
+
         commit_order_err_matches!(
             test_setup,
             OrderErr::Bundle(BundleErr::TargetBlockIncorrect {
-                block: BUILT_BLOCK_NUMBER,
+                block: built_block_number_u256,
                 target_block: PREV_PREV_BUILT_BLOCK_NUMBER,
                 target_max_block: PREV_BUILT_BLOCK_NUMBER
             })
@@ -148,7 +152,7 @@ fn test_target_block() -> eyre::Result<()> {
         commit_order_err_matches!(
             test_setup,
             OrderErr::Bundle(BundleErr::TargetBlockIncorrect {
-                block: BUILT_BLOCK_NUMBER,
+                block: built_block_number_u256,
                 target_block: NEXT_BUILT_BLOCK_NUMBER,
                 target_max_block: NEXT_NEXT_BUILT_BLOCK_NUMBER
             })

--- a/crates/rbuilder/src/building/tx_sim_cache/result_store.rs
+++ b/crates/rbuilder/src/building/tx_sim_cache/result_store.rs
@@ -132,6 +132,7 @@ impl<R: Clone + std::fmt::Debug> ExecutionResultStoreWalker<R> {
 #[cfg(test)]
 mod tests {
     use crate::utils::test_utils::{addr, u256};
+    use reth::revm::state::CodeSize;
 
     use super::*;
 
@@ -145,6 +146,7 @@ mod tests {
                 nonce: 0,
                 code_hash: Default::default(),
                 code: None,
+                code_size: CodeSize::Known(0),
             }),
         }
     }

--- a/crates/rbuilder/src/live_builder/building/mod.rs
+++ b/crates/rbuilder/src/live_builder/building/mod.rs
@@ -108,7 +108,13 @@ where
             );
         // sink removal is automatic via OrderSink::is_alive false
         let _block_sub = self.orderpool_subscriber.add_sink(
-            block_ctx.evm_env.block_env.number,
+            block_ctx
+                .evm_env
+                .block_env
+                .number
+                .to_string()
+                .parse::<u64>()
+                .unwrap(),
             Box::new(mempool_txs_detector_sniffer),
         );
 
@@ -142,7 +148,7 @@ where
         for builder in self.builders.iter() {
             let builder_name = builder.name();
             debug!(
-                block = block_number,
+                block = block_number.to_string(),
                 payload_id = ctx.payload_id,
                 builder_name,
                 "Spawning builder job"
@@ -158,7 +164,7 @@ where
             tokio::task::spawn_blocking(move || {
                 builder.build_blocks(input);
                 debug!(
-                    block = block_number,
+                    block = block_number.to_string(),
                     payload_id = ctx.payload_id,
                     builder_name,
                     "Stopped builder job"

--- a/crates/rbuilder/src/live_builder/order_input/txpool_fetcher.rs
+++ b/crates/rbuilder/src/live_builder/order_input/txpool_fetcher.rs
@@ -117,6 +117,7 @@ mod test {
 
     use super::*;
     use alloy_consensus::{SidecarBuilder, SimpleCoder};
+    use alloy_eips::eip7594::BlobTransactionSidecarVariant;
     use alloy_network::{EthereumWallet, TransactionBuilder};
     use alloy_node_bindings::Anvil;
     use alloy_primitives::U256;
@@ -182,8 +183,12 @@ mod test {
         }
         .unwrap();
 
+        let blob_len = match tx_with_blobs.blobs_sidecar.as_ref() {
+            BlobTransactionSidecarVariant::Eip4844(b_4844) => b_4844.blobs.len(),
+            BlobTransactionSidecarVariant::Eip7594(b_7954) => b_7954.blobs.len(),
+        };
         assert_eq!(tx_with_blobs.hash(), *pending_tx.tx_hash());
-        assert_eq!(tx_with_blobs.blobs_sidecar.blobs.len(), 1);
+        assert_eq!(blob_len, 1);
 
         // send another tx without blobs
         let tx = TransactionRequest::default()
@@ -205,6 +210,11 @@ mod test {
         .unwrap();
 
         assert_eq!(tx_without_blobs.hash(), *pending_tx.tx_hash());
-        assert_eq!(tx_without_blobs.blobs_sidecar.blobs.len(), 0);
+        let blob_len = match tx_without_blobs.blobs_sidecar.as_ref() {
+            BlobTransactionSidecarVariant::Eip4844(b_4844) => b_4844.blobs.len(),
+            BlobTransactionSidecarVariant::Eip7594(b_7954) => b_7954.blobs.len(),
+        };
+
+        assert_eq!(blob_len, 0);
     }
 }

--- a/crates/rbuilder/src/live_builder/simulation/mod.rs
+++ b/crates/rbuilder/src/live_builder/simulation/mod.rs
@@ -130,7 +130,7 @@ where
         let provider = self.provider.clone();
         let current_contexts = Arc::clone(&self.current_contexts);
         let block_context: BlockContextId = gen_uid();
-        let span = info_span!("sim_ctx", block = ctx.evm_env.block_env.number, parent = ?ctx.attributes.parent);
+        let span = info_span!("sim_ctx", block = ctx.evm_env.block_env.number.to_string().parse::<u64>().unwrap(), parent = ?ctx.attributes.parent);
 
         let handle = tokio::spawn(
             async move {

--- a/crates/rbuilder/src/mev_boost/mod.rs
+++ b/crates/rbuilder/src/mev_boost/mod.rs
@@ -486,6 +486,7 @@ impl RelayClient {
         let (mut body_data, content_type) = if ssz {
             (
                 match &submission_with_metadata.submission {
+                    SubmitBlockRequest::Fulu(data) => data.0.as_ssz_bytes(),
                     SubmitBlockRequest::Capella(data) => data.0.as_ssz_bytes(),
                     SubmitBlockRequest::Deneb(data) => data.0.as_ssz_bytes(),
                     SubmitBlockRequest::Electra(data) => data.0.as_ssz_bytes(),

--- a/crates/rbuilder/src/mev_boost/sign_payload.rs
+++ b/crates/rbuilder/src/mev_boost/sign_payload.rs
@@ -12,9 +12,7 @@ use alloy_rpc_types_beacon::{
     relay::{BidTrace, SignedBidSubmissionV2, SignedBidSubmissionV3, SignedBidSubmissionV4},
     BlsPublicKey,
 };
-use alloy_rpc_types_engine::{
-    BlobsBundleV1, ExecutionPayloadV1, ExecutionPayloadV2, ExecutionPayloadV3,
-};
+use alloy_rpc_types_engine::{BlobsBundleV1, BlobsBundleV2, ExecutionPayloadV1, ExecutionPayloadV2, ExecutionPayloadV3};
 use alloy_rpc_types_eth::Withdrawal;
 use ethereum_consensus::{
     crypto::SecretKey,
@@ -27,6 +25,7 @@ use reth_chainspec::{ChainSpec, EthereumHardforks};
 use reth_primitives::SealedBlock;
 use serde_with::{serde_as, DisplayFromStr};
 use std::sync::Arc;
+use alloy_eips::eip7594::{BlobTransactionSidecarEip7594, BlobTransactionSidecarVariant};
 
 /// Object to sign blocks to be sent to relays.
 #[derive(Debug, Clone)]
@@ -120,7 +119,7 @@ fn a2e_address(a: &Address) -> ExecutionAddress {
 pub fn sign_block_for_relay(
     signer: &BLSBlockSigner,
     sealed_block: &SealedBlock,
-    blobs_bundle: &[Arc<BlobTransactionSidecar>],
+    blobs_bundle: &[Arc<BlobTransactionSidecarVariant>],
     execution_requests: &[Bytes], // The Pectra execution requests for this bid.
     chain_spec: &ChainSpec,
     attrs: &PayloadAttributesData,
@@ -235,12 +234,32 @@ fn flatten_marshal<Source>(
     flatten_data.collect::<Vec<Source>>()
 }
 
+fn flatten_marshal_eip7549<Source>(
+    txs_blobs_sidecars: &[Arc<BlobTransactionSidecarEip7594>],
+    vec_getter: impl Fn(&Arc<BlobTransactionSidecarEip7594>) -> Vec<Source>,
+) -> Vec<Source> {
+    let flatten_data = txs_blobs_sidecars.iter().flat_map(vec_getter);
+    flatten_data.collect::<Vec<Source>>()
+}
+
 fn marshal_txs_blobs_sidecars(txs_blobs_sidecars: &[Arc<BlobTransactionSidecar>]) -> BlobsBundleV1 {
     let rpc_commitments = flatten_marshal(txs_blobs_sidecars, |t| t.commitments.clone());
     let rpc_proofs = flatten_marshal(txs_blobs_sidecars, |t| t.proofs.clone());
     let rpc_blobs = flatten_marshal(txs_blobs_sidecars, |t| t.blobs.clone());
 
     BlobsBundleV1 {
+        commitments: rpc_commitments,
+        proofs: rpc_proofs,
+        blobs: rpc_blobs,
+    }
+}
+
+fn marshall_txs_blobs_sidecars_v2(txs_blobs_sidecars: &[Arc<BlobTransactionSidecarEip7594>]) -> BlobsBundleV2 {
+    let rpc_commitments = flatten_marshal_eip7549(txs_blobs_sidecars, |t| t.commitments.clone());
+    let rpc_proofs = flatten_marshal_eip7549(txs_blobs_sidecars, |t| t.proofs.clone());
+    let rpc_blobs = flatten_marshal_eip7549(txs_blobs_sidecars, |t| t.blobs.clone());
+
+    BlobsBundleV2 {
         commitments: rpc_commitments,
         proofs: rpc_proofs,
         blobs: rpc_blobs,

--- a/crates/rbuilder/src/mev_boost/sign_payload.rs
+++ b/crates/rbuilder/src/mev_boost/sign_payload.rs
@@ -1,18 +1,22 @@
 use super::submission::{
     CapellaSubmitBlockRequest, DenebSubmitBlockRequest, ElectraSubmitBlockRequest,
-    SubmitBlockRequest,
+    FuluSubmitBlockRequest, SubmitBlockRequest,
 };
 use crate::utils::u256decimal_serde_helper;
+use alloy_eips::eip7594::{BlobTransactionSidecarEip7594, BlobTransactionSidecarVariant};
 use alloy_eips::eip7685::Requests;
 use alloy_eips::{eip2718::Encodable2718, eip4844::BlobTransactionSidecar};
 use alloy_primitives::{Address, BlockHash, Bytes, FixedBytes, B256, U256};
+use alloy_rpc_types_beacon::relay::SignedBidSubmissionV5;
 use alloy_rpc_types_beacon::requests::ExecutionRequestsV4;
 use alloy_rpc_types_beacon::{
     events::PayloadAttributesData,
     relay::{BidTrace, SignedBidSubmissionV2, SignedBidSubmissionV3, SignedBidSubmissionV4},
     BlsPublicKey,
 };
-use alloy_rpc_types_engine::{BlobsBundleV1, BlobsBundleV2, ExecutionPayloadV1, ExecutionPayloadV2, ExecutionPayloadV3};
+use alloy_rpc_types_engine::{
+    BlobsBundleV1, BlobsBundleV2, ExecutionPayloadV1, ExecutionPayloadV2, ExecutionPayloadV3,
+};
 use alloy_rpc_types_eth::Withdrawal;
 use ethereum_consensus::{
     crypto::SecretKey,
@@ -25,7 +29,6 @@ use reth_chainspec::{ChainSpec, EthereumHardforks};
 use reth_primitives::SealedBlock;
 use serde_with::{serde_as, DisplayFromStr};
 use std::sync::Arc;
-use alloy_eips::eip7594::{BlobTransactionSidecarEip7594, BlobTransactionSidecarVariant};
 
 /// Object to sign blocks to be sent to relays.
 #[derive(Debug, Clone)]
@@ -195,10 +198,12 @@ pub fn sign_block_for_relay(
                 .expect("deneb block does not have excess blob gas"),
         };
 
-        let blobs_bundle = marshal_txs_blobs_sidecars(blobs_bundle);
         let execution_requests =
             ExecutionRequestsV4::try_from(Requests::new(execution_requests.to_vec()))?;
+
         if chain_spec.is_prague_active_at_timestamp(sealed_block.timestamp) {
+            let blobs_bundle = marshal_txs_blobs_sidecars(blobs_bundle);
+
             SubmitBlockRequest::Electra(ElectraSubmitBlockRequest(SignedBidSubmissionV4 {
                 message,
                 execution_payload,
@@ -206,7 +211,19 @@ pub fn sign_block_for_relay(
                 signature,
                 execution_requests,
             }))
+        } else if chain_spec.is_osaka_active_at_timestamp(sealed_block.timestamp) {
+            let blobs_bundle_v2 = marshall_txs_blobs_sidecars_v2(blobs_bundle);
+
+            SubmitBlockRequest::Fulu(FuluSubmitBlockRequest(SignedBidSubmissionV5 {
+                message,
+                execution_payload,
+                blobs_bundle: blobs_bundle_v2,
+                signature,
+                execution_requests,
+            }))
         } else {
+            let blobs_bundle = marshal_txs_blobs_sidecars(blobs_bundle);
+
             SubmitBlockRequest::Deneb(DenebSubmitBlockRequest(SignedBidSubmissionV3 {
                 message,
                 execution_payload,
@@ -242,10 +259,20 @@ fn flatten_marshal_eip7549<Source>(
     flatten_data.collect::<Vec<Source>>()
 }
 
-fn marshal_txs_blobs_sidecars(txs_blobs_sidecars: &[Arc<BlobTransactionSidecar>]) -> BlobsBundleV1 {
-    let rpc_commitments = flatten_marshal(txs_blobs_sidecars, |t| t.commitments.clone());
-    let rpc_proofs = flatten_marshal(txs_blobs_sidecars, |t| t.proofs.clone());
-    let rpc_blobs = flatten_marshal(txs_blobs_sidecars, |t| t.blobs.clone());
+fn marshal_txs_blobs_sidecars(
+    txs_blobs_sidecars: &[Arc<BlobTransactionSidecarVariant>],
+) -> BlobsBundleV1 {
+    let mut eip4844_sidecars = Vec::new();
+    for blob in txs_blobs_sidecars {
+        if let Some(bb) = blob.as_ref().as_eip4844() {
+            // TODO - bharath: cloning here is a terrible idea
+            eip4844_sidecars.push(Arc::new(bb.clone()))
+        }
+    }
+
+    let rpc_commitments = flatten_marshal(eip4844_sidecars.as_slice(), |t| t.commitments.clone());
+    let rpc_proofs = flatten_marshal(eip4844_sidecars.as_slice(), |t| t.proofs.clone());
+    let rpc_blobs = flatten_marshal(eip4844_sidecars.as_slice(), |t| t.blobs.clone());
 
     BlobsBundleV1 {
         commitments: rpc_commitments,
@@ -254,10 +281,22 @@ fn marshal_txs_blobs_sidecars(txs_blobs_sidecars: &[Arc<BlobTransactionSidecar>]
     }
 }
 
-fn marshall_txs_blobs_sidecars_v2(txs_blobs_sidecars: &[Arc<BlobTransactionSidecarEip7594>]) -> BlobsBundleV2 {
-    let rpc_commitments = flatten_marshal_eip7549(txs_blobs_sidecars, |t| t.commitments.clone());
-    let rpc_proofs = flatten_marshal_eip7549(txs_blobs_sidecars, |t| t.proofs.clone());
-    let rpc_blobs = flatten_marshal_eip7549(txs_blobs_sidecars, |t| t.blobs.clone());
+fn marshall_txs_blobs_sidecars_v2(
+    txs_blobs_sidecars: &[Arc<BlobTransactionSidecarVariant>],
+) -> BlobsBundleV2 {
+    let mut eip7549_sidecars = Vec::new();
+    for blob in txs_blobs_sidecars {
+        if let Some(bb) = blob.as_ref().as_eip7594() {
+            // TODO - bharath: cloning here is a terrible idea
+            eip7549_sidecars.push(Arc::new(bb.clone()))
+        }
+    }
+
+    let rpc_commitments =
+        flatten_marshal_eip7549(eip7549_sidecars.as_slice(), |t| t.commitments.clone());
+    let rpc_proofs =
+        flatten_marshal_eip7549(eip7549_sidecars.as_slice(), |t| t.cell_proofs.clone());
+    let rpc_blobs = flatten_marshal_eip7549(eip7549_sidecars.as_slice(), |t| t.blobs.clone());
 
     BlobsBundleV2 {
         commitments: rpc_commitments,

--- a/crates/rbuilder/src/mev_boost/submission.rs
+++ b/crates/rbuilder/src/mev_boost/submission.rs
@@ -4,11 +4,15 @@ use alloy_rpc_types_beacon::{
     requests::ExecutionRequestsV4,
     BlsSignature,
 };
-use alloy_rpc_types_engine::{BlobsBundleV1, ExecutionPayloadV3};
+use alloy_rpc_types_beacon::relay::SignedBidSubmissionV5;
+use alloy_rpc_types_engine::{BlobsBundleV1, BlobsBundleV2, ExecutionPayloadV3};
 use serde::{Deserialize, Serialize};
 use ssz::{Decode, DecodeError, Encode};
 
 use crate::primitives::OrderId;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct FuluSubmitBlockRequest(pub SignedBidSubmissionV5);
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ElectraSubmitBlockRequest(pub SignedBidSubmissionV4);
@@ -28,6 +32,7 @@ pub struct CapellaSubmitBlockRequest(pub SignedBidSubmissionV2);
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum SubmitBlockRequest {
+    Fulu(FuluSubmitBlockRequest),
     Capella(CapellaSubmitBlockRequest),
     Deneb(DenebSubmitBlockRequest),
     Electra(ElectraSubmitBlockRequest),
@@ -36,6 +41,7 @@ pub enum SubmitBlockRequest {
 impl SubmitBlockRequest {
     pub fn bid_trace(&self) -> &BidTrace {
         match self {
+            SubmitBlockRequest::Fulu(req) => &req.0.message,
             SubmitBlockRequest::Capella(req) => &req.0.message,
             SubmitBlockRequest::Deneb(req) => &req.0.message,
             SubmitBlockRequest::Electra(req) => &req.0.message,
@@ -43,6 +49,11 @@ impl SubmitBlockRequest {
     }
 
     pub fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, DecodeError> {
+        if let Ok(result) = SignedBidSubmissionV5::from_ssz_bytes(bytes) {
+            return Ok(SubmitBlockRequest::Fulu(FuluSubmitBlockRequest(
+                result,
+            )));
+        }
         if let Ok(result) = SignedBidSubmissionV4::from_ssz_bytes(bytes) {
             return Ok(SubmitBlockRequest::Electra(ElectraSubmitBlockRequest(
                 result,
@@ -125,6 +136,26 @@ impl serde::Serialize for SubmitBlockRequestNoBlobs<'_> {
                     execution_requests: &v4.0.execution_requests,
                 }
                 .serialize(serializer)
+            },
+            SubmitBlockRequest::Fulu(v5) => {
+                #[derive(serde::Serialize)]
+                struct SignedBidSubmissionV5Ref<'a> {
+                    message: &'a BidTrace,
+                    #[serde(with = "alloy_rpc_types_beacon::payload::beacon_payload_v3")]
+                    execution_payload: &'a ExecutionPayloadV3,
+                    blobs_bundle: &'a BlobsBundleV2,
+                    execution_requests: &'a ExecutionRequestsV4,
+                    signature: &'a BlsSignature,
+                }
+
+                SignedBidSubmissionV5Ref {
+                    message: &v5.0.message,
+                    execution_payload: &v5.0.execution_payload,
+                    blobs_bundle: &BlobsBundleV2::new([]), // override blobs bundle with empty one
+                    signature: &v5.0.signature,
+                    execution_requests: &v5.0.execution_requests,
+                }
+                    .serialize(serializer)
             }
         }
     }

--- a/crates/rbuilder/src/mev_boost/submission.rs
+++ b/crates/rbuilder/src/mev_boost/submission.rs
@@ -1,10 +1,10 @@
 use alloy_primitives::U256;
+use alloy_rpc_types_beacon::relay::SignedBidSubmissionV5;
 use alloy_rpc_types_beacon::{
     relay::{BidTrace, SignedBidSubmissionV2, SignedBidSubmissionV3, SignedBidSubmissionV4},
     requests::ExecutionRequestsV4,
     BlsSignature,
 };
-use alloy_rpc_types_beacon::relay::SignedBidSubmissionV5;
 use alloy_rpc_types_engine::{BlobsBundleV1, BlobsBundleV2, ExecutionPayloadV3};
 use serde::{Deserialize, Serialize};
 use ssz::{Decode, DecodeError, Encode};
@@ -50,9 +50,7 @@ impl SubmitBlockRequest {
 
     pub fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, DecodeError> {
         if let Ok(result) = SignedBidSubmissionV5::from_ssz_bytes(bytes) {
-            return Ok(SubmitBlockRequest::Fulu(FuluSubmitBlockRequest(
-                result,
-            )));
+            return Ok(SubmitBlockRequest::Fulu(FuluSubmitBlockRequest(result)));
         }
         if let Ok(result) = SignedBidSubmissionV4::from_ssz_bytes(bytes) {
             return Ok(SubmitBlockRequest::Electra(ElectraSubmitBlockRequest(
@@ -136,7 +134,7 @@ impl serde::Serialize for SubmitBlockRequestNoBlobs<'_> {
                     execution_requests: &v4.0.execution_requests,
                 }
                 .serialize(serializer)
-            },
+            }
             SubmitBlockRequest::Fulu(v5) => {
                 #[derive(serde::Serialize)]
                 struct SignedBidSubmissionV5Ref<'a> {
@@ -155,7 +153,7 @@ impl serde::Serialize for SubmitBlockRequestNoBlobs<'_> {
                     signature: &v5.0.signature,
                     execution_requests: &v5.0.execution_requests,
                 }
-                    .serialize(serializer)
+                .serialize(serializer)
             }
         }
     }

--- a/crates/rbuilder/src/primitives/mod.rs
+++ b/crates/rbuilder/src/primitives/mod.rs
@@ -9,6 +9,7 @@ mod test_data_generator;
 
 use crate::building::evm_inspector::UsedStateTrace;
 use alloy_consensus::Transaction as _;
+use alloy_eips::eip7594::{BlobTransactionSidecarEip7594, BlobTransactionSidecarVariant};
 use alloy_eips::{
     eip2718::{Decodable2718, Eip2718Error, Encodable2718},
     eip4844::{Blob, BlobTransactionSidecar, Bytes48},
@@ -21,6 +22,7 @@ use reth::transaction_pool::{
     BlobStore, BlobStoreError, EthPooledTransaction, Pool, TransactionOrdering, TransactionPool,
     TransactionValidator,
 };
+use reth_ethereum_primitives::PooledTransactionVariant;
 use reth_node_core::primitives::SignedTransaction;
 use reth_primitives::{
     kzg::{BYTES_PER_BLOB, BYTES_PER_COMMITMENT, BYTES_PER_PROOF},
@@ -30,8 +32,6 @@ use reth_primitives_traits::SignerRecoverable;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::{cmp::Ordering, collections::HashMap, fmt::Display, hash::Hash, str::FromStr, sync::Arc};
-use alloy_eips::eip7594::{BlobTransactionSidecarEip7594, BlobTransactionSidecarVariant};
-use reth_ethereum_primitives::PooledTransactionVariant;
 pub use test_data_generator::TestDataGenerator;
 use thiserror::Error;
 use uuid::Uuid;
@@ -713,19 +713,32 @@ impl TransactionSignedEcRecoveredWithBlobs {
         } else if blob_sidecar.is_some() && tx.inner().blob_versioned_hashes().is_none() {
             Err(TxWithBlobsCreateError::BlobsMissingEip4844)
         // Groovy!
+        // No blob txs at all
+        } else if blob_sidecar.is_none() && tx.inner().blob_versioned_hashes().is_none() {
+            Ok(Self {
+                tx,
+                blobs_sidecar: Arc::new(BlobTransactionSidecarVariant::Eip4844(
+                    BlobTransactionSidecar::default(),
+                )),
+                metadata: metadata.unwrap_or_default(),
+            })
         } else {
-            let unwrapped_blob_sidecar = blob_sidecar.unwrap();
-            if unwrapped_blob_sidecar.is_eip4844() {
+            let b_sidecar = blob_sidecar.unwrap();
+            if b_sidecar.is_eip4844() {
                 Ok(Self {
                     tx,
-                    blobs_sidecar: Arc::new(BlobTransactionSidecarVariant::from(unwrapped_blob_sidecar.into_eip4844().unwrap_or_default())),
-                    metadata: metadata.unwrap_or_default()
+                    blobs_sidecar: Arc::new(BlobTransactionSidecarVariant::from(
+                        b_sidecar.into_eip4844().unwrap_or_default(),
+                    )),
+                    metadata: metadata.unwrap_or_default(),
                 })
             } else {
                 Ok(Self {
                     tx,
-                    blobs_sidecar: Arc::new(BlobTransactionSidecarVariant::from(unwrapped_blob_sidecar.into_eip7594().unwrap_or_default())),
-                    metadata: metadata.unwrap_or_default()
+                    blobs_sidecar: Arc::new(BlobTransactionSidecarVariant::from(
+                        b_sidecar.into_eip7594().unwrap_or_default(),
+                    )),
+                    metadata: metadata.unwrap_or_default(),
                 })
             }
         }
@@ -754,7 +767,8 @@ impl TransactionSignedEcRecoveredWithBlobs {
         S: BlobStore,
     {
         let blob_sidecar = pool
-            .get_blob(*tx.inner().hash())?.and_then(|arc| Arc::try_unwrap(arc).ok());
+            .get_blob(*tx.inner().hash())?
+            .and_then(|arc| Arc::try_unwrap(arc).ok());
         Self::new(tx, blob_sidecar, None)
     }
 
@@ -1039,10 +1053,12 @@ impl Order {
     pub fn has_blobs(&self) -> bool {
         self.list_txs()
             .iter()
-            .any(|(tx, _)| {
-                match tx.blobs_sidecar.as_ref() {
-                    BlobTransactionSidecarVariant::Eip4844(eip4844_sidecar) => !eip4844_sidecar.blobs.is_empty(),
-                    BlobTransactionSidecarVariant::Eip7594(eip7594_sidecar) => !eip7594_sidecar.blobs.is_empty()
+            .any(|(tx, _)| match tx.blobs_sidecar.as_ref() {
+                BlobTransactionSidecarVariant::Eip4844(eip4844_sidecar) => {
+                    !eip4844_sidecar.blobs.is_empty()
+                }
+                BlobTransactionSidecarVariant::Eip7594(eip7594_sidecar) => {
+                    !eip7594_sidecar.blobs.is_empty()
                 }
             })
     }

--- a/crates/rbuilder/src/primitives/mod.rs
+++ b/crates/rbuilder/src/primitives/mod.rs
@@ -30,6 +30,8 @@ use reth_primitives_traits::SignerRecoverable;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::{cmp::Ordering, collections::HashMap, fmt::Display, hash::Hash, str::FromStr, sync::Arc};
+use alloy_eips::eip7594::{BlobTransactionSidecarEip7594, BlobTransactionSidecarVariant};
+use reth_ethereum_primitives::PooledTransactionVariant;
 pub use test_data_generator::TestDataGenerator;
 use thiserror::Error;
 use uuid::Uuid;
@@ -629,7 +631,7 @@ impl ShareBundle {
 pub struct TransactionSignedEcRecoveredWithBlobs {
     tx: Recovered<TransactionSigned>,
     /// Will have a non empty BlobTransactionSidecar if Recovered<TransactionSigned> is 4844
-    pub blobs_sidecar: Arc<BlobTransactionSidecar>,
+    pub blobs_sidecar: Arc<BlobTransactionSidecarVariant>,
 
     #[derivative(PartialEq = "ignore", Hash = "ignore")]
     pub metadata: Metadata,
@@ -701,7 +703,7 @@ impl TransactionSignedEcRecoveredWithBlobs {
     /// or blobs without an eip4844.
     pub fn new(
         tx: Recovered<TransactionSigned>,
-        blob_sidecar: Option<BlobTransactionSidecar>,
+        blob_sidecar: Option<BlobTransactionSidecarVariant>,
         metadata: Option<Metadata>,
     ) -> Result<Self, TxWithBlobsCreateError> {
         // Check for an eip4844 tx passed without blobs
@@ -712,11 +714,20 @@ impl TransactionSignedEcRecoveredWithBlobs {
             Err(TxWithBlobsCreateError::BlobsMissingEip4844)
         // Groovy!
         } else {
-            Ok(Self {
-                tx,
-                blobs_sidecar: Arc::new(blob_sidecar.unwrap_or_default()),
-                metadata: metadata.unwrap_or_default(),
-            })
+            let unwrapped_blob_sidecar = blob_sidecar.unwrap();
+            if unwrapped_blob_sidecar.is_eip4844() {
+                Ok(Self {
+                    tx,
+                    blobs_sidecar: Arc::new(BlobTransactionSidecarVariant::from(unwrapped_blob_sidecar.into_eip4844().unwrap_or_default())),
+                    metadata: metadata.unwrap_or_default()
+                })
+            } else {
+                Ok(Self {
+                    tx,
+                    blobs_sidecar: Arc::new(BlobTransactionSidecarVariant::from(unwrapped_blob_sidecar.into_eip7594().unwrap_or_default())),
+                    metadata: metadata.unwrap_or_default()
+                })
+            }
         }
     }
 
@@ -743,16 +754,16 @@ impl TransactionSignedEcRecoveredWithBlobs {
         S: BlobStore,
     {
         let blob_sidecar = pool
-            .get_blob(*tx.inner().hash())?
-            .and_then(|b| b.as_eip4844().cloned());
+            .get_blob(*tx.inner().hash())?.and_then(|arc| Arc::try_unwrap(arc).ok());
         Self::new(tx, blob_sidecar, None)
     }
 
     /// Creates a Self with empty blobs sidecar. No consistency check is performed!
     pub fn new_for_testing(tx: Recovered<TransactionSigned>) -> Self {
+        let fake_sidecar = BlobTransactionSidecar::default();
         Self {
             tx,
-            blobs_sidecar: Default::default(),
+            blobs_sidecar: Arc::new(BlobTransactionSidecarVariant::Eip4844(fake_sidecar)),
             metadata: Default::default(),
         }
     }
@@ -801,20 +812,20 @@ impl TransactionSignedEcRecoveredWithBlobs {
         raw_tx: Bytes,
     ) -> Result<TransactionSignedEcRecoveredWithBlobs, TxWithBlobsCreateError> {
         let raw_tx = &mut raw_tx.as_ref();
-        let pooled_tx = PooledTransaction::decode_2718(raw_tx)
+        let pooled_tx = PooledTransactionVariant::decode_2718(raw_tx)
             .map_err(TxWithBlobsCreateError::FailedToDecodeTransaction)?;
         let signer = pooled_tx
             .recover_signer()
             .map_err(|_| TxWithBlobsCreateError::InvalidTransactionSignature)?;
         match pooled_tx {
-            PooledTransaction::Legacy(_)
-            | PooledTransaction::Eip2930(_)
-            | PooledTransaction::Eip1559(_)
-            | PooledTransaction::Eip7702(_) => {
+            PooledTransactionVariant::Legacy(_)
+            | PooledTransactionVariant::Eip2930(_)
+            | PooledTransactionVariant::Eip1559(_)
+            | PooledTransactionVariant::Eip7702(_) => {
                 let tx_signed = TransactionSigned::from(pooled_tx);
                 TransactionSignedEcRecoveredWithBlobs::new_no_blobs(tx_signed.with_signer(signer))
             }
-            PooledTransaction::Eip4844(blob_tx) => {
+            PooledTransactionVariant::Eip4844(blob_tx) => {
                 let (blob_tx, signature, hash) = blob_tx.into_parts();
                 let (blob_tx, sidecar) = blob_tx.into_parts();
                 let tx_signed = TransactionSigned::new_unchecked(
@@ -850,7 +861,7 @@ impl TransactionSignedEcRecoveredWithBlobs {
         }
         Ok(TransactionSignedEcRecoveredWithBlobs {
             tx,
-            blobs_sidecar: Arc::new(fake_sidecar),
+            blobs_sidecar: Arc::new(BlobTransactionSidecarVariant::Eip4844(fake_sidecar)),
             metadata: Metadata::default(),
         })
     }
@@ -1028,7 +1039,12 @@ impl Order {
     pub fn has_blobs(&self) -> bool {
         self.list_txs()
             .iter()
-            .any(|(tx, _)| !tx.blobs_sidecar.blobs.is_empty())
+            .any(|(tx, _)| {
+                match tx.blobs_sidecar.as_ref() {
+                    BlobTransactionSidecarVariant::Eip4844(eip4844_sidecar) => !eip4844_sidecar.blobs.is_empty(),
+                    BlobTransactionSidecarVariant::Eip7594(eip7594_sidecar) => !eip7594_sidecar.blobs.is_empty()
+                }
+            })
     }
 
     pub fn target_block(&self) -> Option<u64> {

--- a/crates/rbuilder/src/provider/ipc_state_provider.rs
+++ b/crates/rbuilder/src/provider/ipc_state_provider.rs
@@ -18,7 +18,7 @@ use reipc::rpc_provider::RpcProvider;
 use reth_errors::{ProviderError, ProviderResult};
 use reth_primitives::{Account, Bytecode};
 use reth_provider::{
-    errors::any::AnyError, AccountReader, BlockHashReader, HashedPostStateProvider,
+    errors::any::AnyError, AccountReader, BlockHashReader, BytecodeReader, HashedPostStateProvider,
     StateProofProvider, StateProvider, StateProviderBox, StateRootProvider, StorageRootProvider,
 };
 use reth_trie::{
@@ -242,26 +242,7 @@ impl IpcStateProvider {
     }
 }
 
-impl StateProvider for IpcStateProvider {
-    /// Get storage of given account
-    fn storage(
-        &self,
-        account: Address,
-        storage_key: StorageKey,
-    ) -> ProviderResult<Option<StorageValue>> {
-        if let Some(storage) = self.storage_cache.get(&(account, storage_key)) {
-            return Ok(*storage);
-        }
-
-        let key: U256 = storage_key.into();
-        let storage = rpc_call(&self.ipc_provider, "eth_getStorageAt", (account, key))?;
-        self.storage_cache.insert((account, storage_key), storage);
-
-        Ok(storage)
-    }
-
-    /// Get account code by its hash
-    /// IMPORTANT: Assumes remote provider (node) has RPC call:"rbuilder_getCodeByHash"
+impl BytecodeReader for IpcStateProvider {
     fn bytecode_by_hash(&self, code_hash: &B256) -> ProviderResult<Option<Bytecode>> {
         let empty_hash = code_hash.is_zero() || *code_hash == KECCAK_EMPTY;
         if empty_hash {
@@ -285,6 +266,49 @@ impl StateProvider for IpcStateProvider {
 
         Ok(bytecode)
     }
+}
+
+impl StateProvider for IpcStateProvider {
+    /// Get storage of given account
+    fn storage(
+        &self,
+        account: Address,
+        storage_key: StorageKey,
+    ) -> ProviderResult<Option<StorageValue>> {
+        if let Some(storage) = self.storage_cache.get(&(account, storage_key)) {
+            return Ok(*storage);
+        }
+
+        let key: U256 = storage_key.into();
+        let storage = rpc_call(&self.ipc_provider, "eth_getStorageAt", (account, key))?;
+        self.storage_cache.insert((account, storage_key), storage);
+
+        Ok(storage)
+    }
+
+    // fn bytecode_by_hash(&self, code_hash: &B256) -> ProviderResult<Option<Bytecode>> {
+    //     let empty_hash = code_hash.is_zero() || *code_hash == KECCAK_EMPTY;
+    //     if empty_hash {
+    //         return Ok(None);
+    //     }
+    //
+    //     if let Some(bytecode) = self.code_cache.get(code_hash) {
+    //         return Ok(Some(bytecode.clone()));
+    //     }
+    //
+    //     let bytecode = rpc_call::<(&B256,), Option<Bytes>>(
+    //         &self.ipc_provider,
+    //         "rbuilder_getCodeByHash",
+    //         (code_hash,),
+    //     )?
+    //     .map(|b| {
+    //         let bytecode = Bytecode::new_raw(b);
+    //         self.code_cache.insert(*code_hash, bytecode.clone());
+    //         bytecode
+    //     });
+    //
+    //     Ok(bytecode)
+    // }
 }
 
 impl BlockHashReader for IpcStateProvider {

--- a/crates/test-relay/src/validation_api_client.rs
+++ b/crates/test-relay/src/validation_api_client.rs
@@ -69,6 +69,8 @@ impl ValidationAPIClient {
         }
 
         let method = match req {
+            // TODO - move this to v5
+            SubmitBlockRequest::Fulu(_) => "flashbots_validateBuilderSubmissionV4",
             SubmitBlockRequest::Capella(_) => "flashbots_validateBuilderSubmissionV2",
             SubmitBlockRequest::Deneb(_) => "flashbots_validateBuilderSubmissionV3",
             SubmitBlockRequest::Electra(_) => "flashbots_validateBuilderSubmissionV4",


### PR DESCRIPTION
Things to consider in rbuilder:

**Breaking changes:**
1. **alloy/nybbles:** https://github.com/alloy-rs/nybbles/pull/17 updates the internal representation of `Nibble` from a `SmallVec<[u8; 64]>` to a `U256`. This breaks code in the merkle eth sparse tree as the code indexes a lot into the `SmallVec` representation
2. **alloy/eips**: https://github.com/alloy-rs/alloy/blob/fusaka/devnet2/crates/eips/src/eip7594/sidecar.rs#L25 we need to use `BlobTransactionSidecarVariant` enum which contains PeerDas type blob sidecars too. The only different b/w EIP-7954 sidecars from EIP-4844 sidecars is EIP-7954 sidecars use `cell_proofs` instead of `proofs`. rbuilder just uses `BlobTransactionSidecar` which breaks with the fulu hard fork.
3. **revm/context**: https://github.com/bluealloy/revm/commit/c70bb9a8c3d2d1fa3f24bcba744d7825d80a7637 this commit updates the `BlockNumber` and `Timestamp` to use `U256` instead of `u64`. There are inconsistencies in code where u64 is used for block number which fails to build as a result.
4. **revm/state**: changes made for EIP-7907: https://github.com/bluealloy/revm/commit/d8c4567f34e57d7f19804fbe6bc8adf70ee30ace introduces the `CodeSize` field to the `AccountInfo` . It was previously an `Option` but the mentioned commit makes it a mandatory field. 
5. **alloy/evm**: The `Database` trait in the alloy/evm repo now implements `std::fmt::Debug` implemented by https://github.com/alloy-rs/evm/commit/3d6a01b3594f66aaf60bcc93b7b2e3cd552ec7a8. This broke code since a dependency was using the updated `Database` trait from alloy/evm. Using the `Database` trait from alloy/evm seems to have fixed this. 
6. **revm/inspector**: It appears that the `step` method has been removed from the `access_list_inspector`? i haven't dived too deep into this.

**Notes**
1. We need to send `BlobsBundleV2` to the relay. https://github.com/alloy-rs/alloy/blob/fusaka/devnet2/crates/rpc-types-engine/src/payload.rs#L906
2. We need to send a `SignedBidSubmissionV5` to the relay overall: https://github.com/alloy-rs/alloy/blob/main/crates/rpc-types-beacon/src/relay.rs#L183