### PR TITLE
Fulu changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,15 +107,15 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy-chains"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5674914c2cfdb866c21cb0c09d82374ee39a1395cf512e7515f4c014083b3fff"
+checksum = "4195a29a4b87137b2bb02105e746102873bc03561805cf45c0e510c961f160e6"
 dependencies = [
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.0",
  "alloy-rlp",
  "num_enum",
  "serde",
- "strum 0.27.1",
+ "strum 0.27.2",
 ]
 
 [[package]]
@@ -143,13 +143,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "1.0.20"
-source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#000b830535a0b4d6374bc09727e3663fb6af9b89"
+version = "1.0.23"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka-devnet-3#3b877aca44f8d410226d3250b3ce53bcc077642b"
 dependencies = [
- "alloy-eips 1.0.20",
- "alloy-primitives 1.2.1",
+ "alloy-eips 1.0.23",
+ "alloy-primitives 1.3.0",
  "alloy-rlp",
- "alloy-serde 1.0.20",
+ "alloy-serde 1.0.23",
  "alloy-trie 0.9.0",
  "alloy-tx-macros",
  "arbitrary",
@@ -182,28 +182,28 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "1.0.20"
-source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#000b830535a0b4d6374bc09727e3663fb6af9b89"
+version = "1.0.23"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka-devnet-3#3b877aca44f8d410226d3250b3ce53bcc077642b"
 dependencies = [
- "alloy-consensus 1.0.20",
- "alloy-eips 1.0.20",
- "alloy-primitives 1.2.1",
+ "alloy-consensus 1.0.23",
+ "alloy-eips 1.0.23",
+ "alloy-primitives 1.3.0",
  "alloy-rlp",
- "alloy-serde 1.0.20",
+ "alloy-serde 1.0.23",
  "arbitrary",
  "serde",
 ]
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b95b3deca680efc7e9cba781f1a1db352fa1ea50e6384a514944dcf4419e652"
+checksum = "d9e8a436f0aad7df8bb47f144095fba61202265d9f5f09a70b0e3227881a668e"
 dependencies = [
- "alloy-json-abi 1.2.1",
- "alloy-primitives 1.2.1",
- "alloy-sol-type-parser 1.2.1",
- "alloy-sol-types 1.2.1",
+ "alloy-json-abi 1.3.0",
+ "alloy-primitives 1.3.0",
+ "alloy-sol-type-parser 1.3.0",
+ "alloy-sol-types 1.3.0",
  "derive_more 2.0.1",
  "itoa",
  "serde",
@@ -227,10 +227,9 @@ dependencies = [
 [[package]]
 name = "alloy-eip2124"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "741bdd7499908b3aa0b159bba11e71c8cddd009a2c2eb7a06e825f1ec87900a5"
+source = "git+https://github.com/alloy-rs/eips?branch=rkrasiuk%2Ffork-hash-from-bytes-arr#1cc63cb63366e5641927369b130cd43de9623a48"
 dependencies = [
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.0",
  "alloy-rlp",
  "arbitrary",
  "crc",
@@ -256,7 +255,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b82752a889170df67bbb36d42ca63c531eb16274f0d7299ae2a680facba17bd"
 dependencies = [
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.0",
  "alloy-rlp",
  "arbitrary",
  "rand 0.8.5",
@@ -281,7 +280,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d4769c6ffddca380b0070d71c8b7f30bed375543fe76bb2f74ec0acf4b7cd16"
 dependencies = [
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.0",
  "alloy-rlp",
  "arbitrary",
  "k256 0.13.4",
@@ -313,15 +312,15 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "1.0.20"
-source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#000b830535a0b4d6374bc09727e3663fb6af9b89"
+version = "1.0.23"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka-devnet-3#3b877aca44f8d410226d3250b3ce53bcc077642b"
 dependencies = [
  "alloy-eip2124 0.2.0",
  "alloy-eip2930 0.2.1",
  "alloy-eip7702 0.6.1",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.0",
  "alloy-rlp",
- "alloy-serde 1.0.20",
+ "alloy-serde 1.0.23",
  "arbitrary",
  "auto_impl",
  "c-kzg",
@@ -335,15 +334,16 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.13.0"
-source = "git+https://github.com/alloy-rs/evm?branch=fusaka%2Fdevnet2#0f1420656bd704de0ca066414013997a7c455c0d"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28de0dd1bbb0634ef7c3715e8e60176b77b82f8b6b15b2e35fe64cf6640f6550"
 dependencies = [
- "alloy-consensus 1.0.20",
- "alloy-eips 1.0.20",
+ "alloy-consensus 1.0.23",
+ "alloy-eips 1.0.23",
  "alloy-hardforks",
- "alloy-primitives 1.2.1",
- "alloy-rpc-types-eth 1.0.20",
- "alloy-sol-types 1.2.1",
+ "alloy-primitives 1.3.0",
+ "alloy-rpc-types-eth 1.0.23",
+ "alloy-sol-types 1.3.0",
  "auto_impl",
  "derive_more 2.0.1",
  "op-alloy-consensus",
@@ -354,12 +354,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "1.0.20"
-source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#000b830535a0b4d6374bc09727e3663fb6af9b89"
+version = "1.0.23"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka-devnet-3#3b877aca44f8d410226d3250b3ce53bcc077642b"
 dependencies = [
- "alloy-eips 1.0.20",
- "alloy-primitives 1.2.1",
- "alloy-serde 1.0.20",
+ "alloy-eips 1.0.23",
+ "alloy-primitives 1.3.0",
+ "alloy-serde 1.0.23",
  "alloy-trie 0.9.0",
  "serde",
  "serde_with",
@@ -373,7 +373,7 @@ checksum = "819a3620fe125e0fff365363315ee5e24c23169173b19747dfd6deba33db8990"
 dependencies = [
  "alloy-chains",
  "alloy-eip2124 0.2.0",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.0",
  "auto_impl",
  "dyn-clone",
  "serde",
@@ -393,12 +393,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15516116086325c157c18261d768a20677f0f699348000ed391d4ad0dcb82530"
+checksum = "459f98c6843f208856f338bfb25e65325467f7aff35dfeb0484d0a76e059134b"
 dependencies = [
- "alloy-primitives 1.2.1",
- "alloy-sol-type-parser 1.2.1",
+ "alloy-primitives 1.3.0",
+ "alloy-sol-type-parser 1.3.0",
  "serde",
  "serde_json",
 ]
@@ -419,11 +419,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "1.0.20"
-source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#000b830535a0b4d6374bc09727e3663fb6af9b89"
+version = "1.0.23"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka-devnet-3#3b877aca44f8d410226d3250b3ce53bcc077642b"
 dependencies = [
- "alloy-primitives 1.2.1",
- "alloy-sol-types 1.2.1",
+ "alloy-primitives 1.3.0",
+ "alloy-sol-types 1.3.0",
  "http 1.3.1",
  "serde",
  "serde_json",
@@ -433,20 +433,20 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "1.0.20"
-source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#000b830535a0b4d6374bc09727e3663fb6af9b89"
+version = "1.0.23"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka-devnet-3#3b877aca44f8d410226d3250b3ce53bcc077642b"
 dependencies = [
- "alloy-consensus 1.0.20",
- "alloy-consensus-any 1.0.20",
- "alloy-eips 1.0.20",
- "alloy-json-rpc 1.0.20",
- "alloy-network-primitives 1.0.20",
- "alloy-primitives 1.2.1",
+ "alloy-consensus 1.0.23",
+ "alloy-consensus-any 1.0.23",
+ "alloy-eips 1.0.23",
+ "alloy-json-rpc 1.0.23",
+ "alloy-network-primitives 1.0.23",
+ "alloy-primitives 1.3.0",
  "alloy-rpc-types-any",
- "alloy-rpc-types-eth 1.0.20",
- "alloy-serde 1.0.20",
+ "alloy-rpc-types-eth 1.0.23",
+ "alloy-serde 1.0.23",
  "alloy-signer",
- "alloy-sol-types 1.2.1",
+ "alloy-sol-types 1.3.0",
  "async-trait",
  "auto_impl",
  "derive_more 2.0.1",
@@ -471,26 +471,26 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "1.0.20"
-source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#000b830535a0b4d6374bc09727e3663fb6af9b89"
+version = "1.0.23"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka-devnet-3#3b877aca44f8d410226d3250b3ce53bcc077642b"
 dependencies = [
- "alloy-consensus 1.0.20",
- "alloy-eips 1.0.20",
- "alloy-primitives 1.2.1",
- "alloy-serde 1.0.20",
+ "alloy-consensus 1.0.23",
+ "alloy-eips 1.0.23",
+ "alloy-primitives 1.3.0",
+ "alloy-serde 1.0.23",
  "serde",
 ]
 
 [[package]]
 name = "alloy-node-bindings"
-version = "1.0.20"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15fdb7f13794430ec98cf9a8bca8d9509ade14d12b260b6d7b7e0d133f6631fc"
+checksum = "0de75f0d0af3c6cb0bd3648e530289b2c542b7bf57e7d4296d1c29281418a476"
 dependencies = [
  "alloy-genesis",
  "alloy-hardforks",
  "alloy-network",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.0",
  "alloy-signer",
  "alloy-signer-local",
  "k256 0.13.4",
@@ -553,9 +553,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6177ed26655d4e84e00b65cb494d4e0b8830e7cae7ef5d63087d445a2600fb55"
+checksum = "3cfebde8c581a5d37b678d0a48a32decb51efd7a63a08ce2517ddec26db705c8"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -574,7 +574,7 @@ dependencies = [
  "paste",
  "proptest",
  "proptest-derive",
- "rand 0.9.1",
+ "rand 0.9.2",
  "ruint",
  "rustc-hash 2.1.1",
  "serde",
@@ -584,21 +584,21 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "1.0.20"
-source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#000b830535a0b4d6374bc09727e3663fb6af9b89"
+version = "1.0.23"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka-devnet-3#3b877aca44f8d410226d3250b3ce53bcc077642b"
 dependencies = [
  "alloy-chains",
- "alloy-consensus 1.0.20",
- "alloy-eips 1.0.20",
- "alloy-json-rpc 1.0.20",
+ "alloy-consensus 1.0.23",
+ "alloy-eips 1.0.23",
+ "alloy-json-rpc 1.0.23",
  "alloy-network",
- "alloy-network-primitives 1.0.20",
- "alloy-primitives 1.2.1",
+ "alloy-network-primitives 1.0.23",
+ "alloy-primitives 1.3.0",
  "alloy-pubsub",
  "alloy-rpc-client",
- "alloy-rpc-types-eth 1.0.20",
+ "alloy-rpc-types-eth 1.0.23",
  "alloy-signer",
- "alloy-sol-types 1.2.1",
+ "alloy-sol-types 1.3.0",
  "alloy-transport",
  "alloy-transport-http",
  "alloy-transport-ipc",
@@ -626,11 +626,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "1.0.20"
-source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#000b830535a0b4d6374bc09727e3663fb6af9b89"
+version = "1.0.23"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka-devnet-3#3b877aca44f8d410226d3250b3ce53bcc077642b"
 dependencies = [
- "alloy-json-rpc 1.0.20",
- "alloy-primitives 1.2.1",
+ "alloy-json-rpc 1.0.23",
+ "alloy-primitives 1.3.0",
  "alloy-transport",
  "bimap",
  "futures",
@@ -668,17 +668,16 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "1.0.20"
-source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#000b830535a0b4d6374bc09727e3663fb6af9b89"
+version = "1.0.23"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka-devnet-3#3b877aca44f8d410226d3250b3ce53bcc077642b"
 dependencies = [
- "alloy-json-rpc 1.0.20",
- "alloy-primitives 1.2.1",
+ "alloy-json-rpc 1.0.23",
+ "alloy-primitives 1.3.0",
  "alloy-pubsub",
  "alloy-transport",
  "alloy-transport-http",
  "alloy-transport-ipc",
  "alloy-transport-ws",
- "async-stream",
  "futures",
  "pin-project",
  "reqwest 0.12.22",
@@ -688,62 +687,61 @@ dependencies = [
  "tokio-stream",
  "tower 0.5.2",
  "tracing",
- "tracing-futures",
  "url",
  "wasmtimer",
 ]
 
 [[package]]
 name = "alloy-rpc-types"
-version = "1.0.20"
-source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#000b830535a0b4d6374bc09727e3663fb6af9b89"
+version = "1.0.23"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka-devnet-3#3b877aca44f8d410226d3250b3ce53bcc077642b"
 dependencies = [
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.0",
  "alloy-rpc-types-engine",
- "alloy-rpc-types-eth 1.0.20",
- "alloy-serde 1.0.20",
+ "alloy-rpc-types-eth 1.0.23",
+ "alloy-serde 1.0.23",
  "serde",
 ]
 
 [[package]]
 name = "alloy-rpc-types-admin"
-version = "1.0.20"
-source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#000b830535a0b4d6374bc09727e3663fb6af9b89"
+version = "1.0.23"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka-devnet-3#3b877aca44f8d410226d3250b3ce53bcc077642b"
 dependencies = [
  "alloy-genesis",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.0",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "1.0.20"
-source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#000b830535a0b4d6374bc09727e3663fb6af9b89"
+version = "1.0.23"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka-devnet-3#3b877aca44f8d410226d3250b3ce53bcc077642b"
 dependencies = [
- "alloy-primitives 1.2.1",
- "alloy-rpc-types-eth 1.0.20",
- "alloy-serde 1.0.20",
+ "alloy-primitives 1.3.0",
+ "alloy-rpc-types-eth 1.0.23",
+ "alloy-serde 1.0.23",
  "serde",
 ]
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "1.0.20"
-source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#000b830535a0b4d6374bc09727e3663fb6af9b89"
+version = "1.0.23"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka-devnet-3#3b877aca44f8d410226d3250b3ce53bcc077642b"
 dependencies = [
- "alloy-consensus-any 1.0.20",
- "alloy-rpc-types-eth 1.0.20",
- "alloy-serde 1.0.20",
+ "alloy-consensus-any 1.0.23",
+ "alloy-rpc-types-eth 1.0.23",
+ "alloy-serde 1.0.23",
 ]
 
 [[package]]
 name = "alloy-rpc-types-beacon"
-version = "1.0.20"
-source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#000b830535a0b4d6374bc09727e3663fb6af9b89"
+version = "1.0.23"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka-devnet-3#3b877aca44f8d410226d3250b3ce53bcc077642b"
 dependencies = [
- "alloy-eips 1.0.20",
- "alloy-primitives 1.2.1",
+ "alloy-eips 1.0.23",
+ "alloy-primitives 1.3.0",
  "alloy-rpc-types-engine",
  "ethereum_ssz 0.9.0",
  "ethereum_ssz_derive 0.9.0",
@@ -756,30 +754,30 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "1.0.20"
-source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#000b830535a0b4d6374bc09727e3663fb6af9b89"
+version = "1.0.23"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka-devnet-3#3b877aca44f8d410226d3250b3ce53bcc077642b"
 dependencies = [
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.0",
  "serde",
 ]
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "1.0.20"
-source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#000b830535a0b4d6374bc09727e3663fb6af9b89"
+version = "1.0.23"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka-devnet-3#3b877aca44f8d410226d3250b3ce53bcc077642b"
 dependencies = [
- "alloy-consensus 1.0.20",
- "alloy-eips 1.0.20",
- "alloy-primitives 1.2.1",
+ "alloy-consensus 1.0.23",
+ "alloy-eips 1.0.23",
+ "alloy-primitives 1.3.0",
  "alloy-rlp",
- "alloy-serde 1.0.20",
+ "alloy-serde 1.0.23",
  "derive_more 2.0.1",
  "ethereum_ssz 0.9.0",
  "ethereum_ssz_derive 0.9.0",
  "jsonwebtoken 9.3.1",
  "rand 0.8.5",
  "serde",
- "strum 0.27.1",
+ "strum 0.27.2",
 ]
 
 [[package]]
@@ -804,19 +802,19 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "1.0.20"
-source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#000b830535a0b4d6374bc09727e3663fb6af9b89"
+version = "1.0.23"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka-devnet-3#3b877aca44f8d410226d3250b3ce53bcc077642b"
 dependencies = [
- "alloy-consensus 1.0.20",
- "alloy-consensus-any 1.0.20",
- "alloy-eips 1.0.20",
- "alloy-network-primitives 1.0.20",
- "alloy-primitives 1.2.1",
+ "alloy-consensus 1.0.23",
+ "alloy-consensus-any 1.0.23",
+ "alloy-eips 1.0.23",
+ "alloy-network-primitives 1.0.23",
+ "alloy-primitives 1.3.0",
  "alloy-rlp",
- "alloy-serde 1.0.20",
- "alloy-sol-types 1.2.1",
+ "alloy-serde 1.0.23",
+ "alloy-sol-types 1.3.0",
  "arbitrary",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -825,26 +823,26 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-mev"
-version = "1.0.20"
-source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#000b830535a0b4d6374bc09727e3663fb6af9b89"
+version = "1.0.23"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka-devnet-3#3b877aca44f8d410226d3250b3ce53bcc077642b"
 dependencies = [
- "alloy-consensus 1.0.20",
- "alloy-eips 1.0.20",
- "alloy-primitives 1.2.1",
- "alloy-rpc-types-eth 1.0.20",
- "alloy-serde 1.0.20",
+ "alloy-consensus 1.0.23",
+ "alloy-eips 1.0.23",
+ "alloy-primitives 1.3.0",
+ "alloy-rpc-types-eth 1.0.23",
+ "alloy-serde 1.0.23",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "1.0.20"
-source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#000b830535a0b4d6374bc09727e3663fb6af9b89"
+version = "1.0.23"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka-devnet-3#3b877aca44f8d410226d3250b3ce53bcc077642b"
 dependencies = [
- "alloy-primitives 1.2.1",
- "alloy-rpc-types-eth 1.0.20",
- "alloy-serde 1.0.20",
+ "alloy-primitives 1.3.0",
+ "alloy-rpc-types-eth 1.0.23",
+ "alloy-serde 1.0.23",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -852,12 +850,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-txpool"
-version = "1.0.20"
-source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#000b830535a0b4d6374bc09727e3663fb6af9b89"
+version = "1.0.23"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka-devnet-3#3b877aca44f8d410226d3250b3ce53bcc077642b"
 dependencies = [
- "alloy-primitives 1.2.1",
- "alloy-rpc-types-eth 1.0.20",
- "alloy-serde 1.0.20",
+ "alloy-primitives 1.3.0",
+ "alloy-rpc-types-eth 1.0.23",
+ "alloy-serde 1.0.23",
  "serde",
 ]
 
@@ -874,10 +872,10 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "1.0.20"
-source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#000b830535a0b4d6374bc09727e3663fb6af9b89"
+version = "1.0.23"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka-devnet-3#3b877aca44f8d410226d3250b3ce53bcc077642b"
 dependencies = [
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.0",
  "arbitrary",
  "serde",
  "serde_json",
@@ -885,10 +883,10 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "1.0.20"
-source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#000b830535a0b4d6374bc09727e3663fb6af9b89"
+version = "1.0.23"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka-devnet-3#3b877aca44f8d410226d3250b3ce53bcc077642b"
 dependencies = [
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.0",
  "async-trait",
  "auto_impl",
  "either",
@@ -899,12 +897,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "1.0.20"
-source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#000b830535a0b4d6374bc09727e3663fb6af9b89"
+version = "1.0.23"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka-devnet-3#3b877aca44f8d410226d3250b3ce53bcc077642b"
 dependencies = [
- "alloy-consensus 1.0.20",
+ "alloy-consensus 1.0.23",
  "alloy-network",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.0",
  "alloy-signer",
  "async-trait",
  "k256 0.13.4",
@@ -928,12 +926,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a14f21d053aea4c6630687c2f4ad614bed4c81e14737a9b904798b24f30ea849"
+checksum = "aedac07a10d4c2027817a43cc1f038313fc53c7ac866f7363239971fd01f9f18"
 dependencies = [
- "alloy-sol-macro-expander 1.2.1",
- "alloy-sol-macro-input 1.2.1",
+ "alloy-sol-macro-expander 1.3.0",
+ "alloy-sol-macro-input 1.3.0",
  "proc-macro-error2",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
@@ -960,11 +958,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34d99282e7c9ef14eb62727981a985a01869e586d1dec729d3bb33679094c100"
+checksum = "24f9a598f010f048d8b8226492b6401104f5a5c1273c2869b72af29b48bb4ba9"
 dependencies = [
- "alloy-sol-macro-input 1.2.1",
+ "alloy-sol-macro-input 1.3.0",
  "const-hex",
  "heck 0.5.0",
  "indexmap 2.10.0",
@@ -972,7 +970,7 @@ dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
  "syn 2.0.104",
- "syn-solidity 1.2.1",
+ "syn-solidity 1.3.0",
  "tiny-keccak",
 ]
 
@@ -994,9 +992,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eda029f955b78e493360ee1d7bd11e1ab9f2a220a5715449babc79d6d0a01105"
+checksum = "f494adf9d60e49aa6ce26dfd42c7417aa6d4343cf2ae621f20e4d92a5ad07d85"
 dependencies = [
  "const-hex",
  "dunce",
@@ -1005,7 +1003,7 @@ dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
  "syn 2.0.104",
- "syn-solidity 1.2.1",
+ "syn-solidity 1.3.0",
 ]
 
 [[package]]
@@ -1020,9 +1018,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10db1bd7baa35bc8d4a1b07efbf734e73e5ba09f2580fb8cee3483a36087ceb2"
+checksum = "52db32fbd35a9c0c0e538b58b81ebbae08a51be029e7ad60e08b60481c2ec6c3"
 dependencies = [
  "serde",
  "winnow",
@@ -1043,23 +1041,23 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58377025a47d8b8426b3e4846a251f2c1991033b27f517aade368146f6ab1dfe"
+checksum = "a285b46e3e0c177887028278f04cc8262b76fd3b8e0e20e93cea0a58c35f5ac5"
 dependencies = [
- "alloy-json-abi 1.2.1",
- "alloy-primitives 1.2.1",
- "alloy-sol-macro 1.2.1",
+ "alloy-json-abi 1.3.0",
+ "alloy-primitives 1.3.0",
+ "alloy-sol-macro 1.3.0",
  "serde",
 ]
 
 [[package]]
 name = "alloy-transport"
-version = "1.0.20"
-source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#000b830535a0b4d6374bc09727e3663fb6af9b89"
+version = "1.0.23"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka-devnet-3#3b877aca44f8d410226d3250b3ce53bcc077642b"
 dependencies = [
- "alloy-json-rpc 1.0.20",
- "alloy-primitives 1.2.1",
+ "alloy-json-rpc 1.0.23",
+ "alloy-primitives 1.3.0",
  "base64 0.22.1",
  "derive_more 2.0.1",
  "futures",
@@ -1077,10 +1075,10 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "1.0.20"
-source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#000b830535a0b4d6374bc09727e3663fb6af9b89"
+version = "1.0.23"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka-devnet-3#3b877aca44f8d410226d3250b3ce53bcc077642b"
 dependencies = [
- "alloy-json-rpc 1.0.20",
+ "alloy-json-rpc 1.0.23",
  "alloy-transport",
  "reqwest 0.12.22",
  "serde_json",
@@ -1091,10 +1089,10 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "1.0.20"
-source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#000b830535a0b4d6374bc09727e3663fb6af9b89"
+version = "1.0.23"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka-devnet-3#3b877aca44f8d410226d3250b3ce53bcc077642b"
 dependencies = [
- "alloy-json-rpc 1.0.20",
+ "alloy-json-rpc 1.0.23",
  "alloy-pubsub",
  "alloy-transport",
  "bytes",
@@ -1110,8 +1108,8 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "1.0.20"
-source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#000b830535a0b4d6374bc09727e3663fb6af9b89"
+version = "1.0.23"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka-devnet-3#3b877aca44f8d410226d3250b3ce53bcc077642b"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -1147,7 +1145,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "983d99aa81f586cef9dae38443245e585840fcf0fc58b09aee0b1f27aed1d500"
 dependencies = [
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.0",
  "alloy-rlp",
  "arrayvec",
  "derive_more 2.0.1",
@@ -1162,7 +1160,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bada1fc392a33665de0dc50d401a3701b62583c655e3522a323490a5da016962"
 dependencies = [
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.0",
  "alloy-rlp",
  "arbitrary",
  "arrayvec",
@@ -1178,10 +1176,10 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "1.0.20"
-source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#000b830535a0b4d6374bc09727e3663fb6af9b89"
+version = "1.0.23"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka-devnet-3#3b877aca44f8d410226d3250b3ce53bcc077642b"
 dependencies = [
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.0",
  "darling 0.20.11",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
@@ -2360,17 +2358,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bstr"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
-dependencies = [
- "memchr",
- "regex-automata 0.4.9",
- "serde",
-]
-
-[[package]]
 name = "built"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2409,9 +2396,9 @@ dependencies = [
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.9.3"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ecc273b49b3205b83d648f0690daa588925572cc5063745bfe547fe7ec8e1a1"
+checksum = "441473f2b4b0459a68628c744bc61d23e730fb00128b841d30fa4bb3972257e4"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
@@ -3262,9 +3249,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.2.0"
+version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373b7c5dbd637569a2cca66e8d66b8c446a1e7bf064ea321d265d7b3dfe7c97e"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -4063,7 +4050,7 @@ dependencies = [
 name = "eth-sparse-mpt"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.0",
  "alloy-rlp",
  "alloy-trie 0.8.1",
  "arrayvec",
@@ -4208,7 +4195,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dc1355dbb41fbbd34ec28d4fb2a57d9a70c67ac3c19f6a5ca4d4a176b9e997a"
 dependencies = [
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.0",
  "hex",
  "serde",
  "serde_derive",
@@ -4232,7 +4219,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ca8ba45b63c389c6e115b095ca16381534fdcc03cf58176a3f8554db2dbe19b"
 dependencies = [
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.0",
  "ethereum_serde_utils 0.8.0",
  "itertools 0.13.0",
  "serde",
@@ -4631,9 +4618,9 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
-version = "0.3.0"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filetime"
@@ -5450,7 +5437,7 @@ dependencies = [
  "idna",
  "ipnet",
  "once_cell",
- "rand 0.9.1",
+ "rand 0.9.2",
  "ring 0.17.14",
  "serde",
  "thiserror 2.0.12",
@@ -5473,7 +5460,7 @@ dependencies = [
  "moka",
  "once_cell",
  "parking_lot",
- "rand 0.9.1",
+ "rand 0.9.2",
  "resolv-conf",
  "serde",
  "smallvec",
@@ -5716,7 +5703,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.2",
  "tower-service",
- "webpki-roots 1.0.1",
+ "webpki-roots 1.0.2",
 ]
 
 [[package]]
@@ -6182,9 +6169,9 @@ dependencies = [
 
 [[package]]
 name = "instability"
-version = "0.3.7"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf9fed6d91cfb734e7476a06bde8300a1b94e217e1b523b6f0cd1a01998c71d"
+checksum = "435d80800b936787d62688c927b6490e887c7ef5ff9ce922c6c6050fca75eb9a"
 dependencies = [
  "darling 0.20.11",
  "indoc",
@@ -6243,9 +6230,9 @@ dependencies = [
 
 [[package]]
 name = "io-uring"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
+checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
 dependencies = [
  "bitflags 2.9.1",
  "cfg-if",
@@ -6507,7 +6494,7 @@ dependencies = [
  "jsonrpsee-types 0.25.1",
  "parking_lot",
  "pin-project",
- "rand 0.9.1",
+ "rand 0.9.2",
  "rustc-hash 2.1.1",
  "serde",
  "serde_json",
@@ -6987,9 +6974,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1580801010e535496706ba011c15f8532df6b42297d2e471fec38ceadd8c0638"
+checksum = "4488594b9328dee448adb906d8b126d9b7deb7cf5c22161ee591610bb1be83c0"
 dependencies = [
  "bitflags 2.9.1",
  "libc",
@@ -7372,7 +7359,7 @@ dependencies = [
  "hashbrown 0.15.4",
  "metrics",
  "quanta",
- "rand 0.9.1",
+ "rand 0.9.2",
  "rand_xoshiro",
  "sketches-ddsketch",
 ]
@@ -7973,15 +7960,15 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "op-alloy-consensus"
-version = "0.18.9"
+version = "0.18.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8719d9b783b29cfa1cf8d591b894805786b9ab4940adc700a57fd0d5b721cf5"
+checksum = "d3c719b26da6d9cac18c3a35634d6ab27a74a304ed9b403b43749c22e57a389f"
 dependencies = [
- "alloy-consensus 1.0.20",
- "alloy-eips 1.0.20",
- "alloy-primitives 1.2.1",
+ "alloy-consensus 1.0.23",
+ "alloy-eips 1.0.23",
+ "alloy-primitives 1.3.0",
  "alloy-rlp",
- "alloy-serde 1.0.20",
+ "alloy-serde 1.0.23",
  "arbitrary",
  "derive_more 2.0.1",
  "serde",
@@ -7991,13 +7978,13 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-rpc-types-engine"
-version = "0.18.9"
+version = "0.18.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a4559d84f079b3fdfd01e4ee0bb118025e92105fbb89736f5d77ab3ca261698"
+checksum = "50cf45d43a3d548fdc39d9bfab6ba13cc06b3214ef4b9c36d3efbf3faea1b9f1"
 dependencies = [
- "alloy-consensus 1.0.20",
- "alloy-eips 1.0.20",
- "alloy-primitives 1.2.1",
+ "alloy-consensus 1.0.23",
+ "alloy-eips 1.0.23",
+ "alloy-primitives 1.3.0",
  "alloy-rlp",
  "alloy-rpc-types-engine",
  "derive_more 2.0.1",
@@ -8010,8 +7997,8 @@ dependencies = [
 
 [[package]]
 name = "op-revm"
-version = "8.0.2"
-source = "git+https://github.com/bluealloy/revm?branch=rakita%2Feip7907#37edc381a940a52abb90b3e0a480292a675e8129"
+version = "8.0.3"
+source = "git+https://github.com/bluealloy/revm?branch=fusaka-devnet-3#d5292dda70a21784d1cf9fcfca957445376e91f0"
 dependencies = [
  "auto_impl",
  "once_cell",
@@ -9044,7 +9031,7 @@ dependencies = [
  "bitflags 2.9.1",
  "lazy_static",
  "num-traits",
- "rand 0.9.1",
+ "rand 0.9.2",
  "rand_chacha 0.9.0",
  "rand_xorshift 0.4.0",
  "regex-syntax 0.8.5",
@@ -9162,7 +9149,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.3",
  "lru-slab",
- "rand 0.9.1",
+ "rand 0.9.2",
  "ring 0.17.14",
  "rustc-hash 2.1.1",
  "rustls 0.23.29",
@@ -9264,9 +9251,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -9511,20 +9498,20 @@ version = "0.1.0"
 dependencies = [
  "ahash",
  "alloy-chains",
- "alloy-consensus 1.0.20",
- "alloy-eips 1.0.20",
+ "alloy-consensus 1.0.23",
+ "alloy-eips 1.0.23",
  "alloy-evm",
- "alloy-json-rpc 1.0.20",
+ "alloy-json-rpc 1.0.23",
  "alloy-network",
- "alloy-network-primitives 1.0.20",
+ "alloy-network-primitives 1.0.23",
  "alloy-node-bindings",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.0",
  "alloy-provider",
  "alloy-rlp",
  "alloy-rpc-types",
  "alloy-rpc-types-beacon",
  "alloy-rpc-types-engine",
- "alloy-rpc-types-eth 1.0.20",
+ "alloy-rpc-types-eth 1.0.23",
  "alloy-signer-local",
  "assert_matches",
  "async-trait",
@@ -9587,7 +9574,7 @@ dependencies = [
  "reth-trie",
  "reth-trie-parallel",
  "revm",
- "revm-inspectors",
+ "revm-inspectors 0.26.5",
  "secp256k1 0.30.0",
  "serde",
  "serde_json",
@@ -9629,9 +9616,9 @@ checksum = "d3edd4d5d42c92f0a659926464d4cce56b562761267ecf0f469d85b7de384175"
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.13"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
+checksum = "7e8af0dde094006011e6a740d4879319439489813bd0bcdc7d821beaeeff48ec"
 dependencies = [
  "bitflags 2.9.1",
 ]
@@ -9841,7 +9828,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 1.0.1",
+ "webpki-roots 1.0.2",
 ]
 
 [[package]]
@@ -9852,8 +9839,8 @@ checksum = "95325155c684b1c89f7765e30bc1c42e4a6da51ca513615660cb8a62ef9a88e3"
 
 [[package]]
 name = "reth"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
  "alloy-rpc-types",
  "aquamarine",
@@ -9898,12 +9885,12 @@ dependencies = [
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-consensus 1.0.20",
- "alloy-eips 1.0.20",
- "alloy-primitives 1.2.1",
+ "alloy-consensus 1.0.23",
+ "alloy-eips 1.0.23",
+ "alloy-primitives 1.3.0",
  "futures-core",
  "futures-util",
  "metrics",
@@ -9922,19 +9909,19 @@ dependencies = [
 
 [[package]]
 name = "reth-chain-state"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-consensus 1.0.20",
- "alloy-eips 1.0.20",
- "alloy-primitives 1.2.1",
+ "alloy-consensus 1.0.23",
+ "alloy-eips 1.0.23",
+ "alloy-primitives 1.3.0",
  "alloy-signer",
  "alloy-signer-local",
  "derive_more 2.0.1",
  "metrics",
  "parking_lot",
  "pin-project",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reth-chainspec",
  "reth-errors",
  "reth-ethereum-primitives",
@@ -9953,15 +9940,15 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
  "alloy-chains",
- "alloy-consensus 1.0.20",
- "alloy-eips 1.0.20",
+ "alloy-consensus 1.0.23",
+ "alloy-eips 1.0.23",
  "alloy-evm",
  "alloy-genesis",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.0",
  "alloy-trie 0.9.0",
  "auto_impl",
  "derive_more 2.0.1",
@@ -9973,8 +9960,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
  "alloy-genesis",
  "clap 4.5.41",
@@ -9987,14 +9974,14 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-commands"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
  "ahash",
  "alloy-chains",
- "alloy-consensus 1.0.20",
- "alloy-eips 1.0.20",
- "alloy-primitives 1.2.1",
+ "alloy-consensus 1.0.23",
+ "alloy-eips 1.0.23",
+ "alloy-primitives 1.3.0",
  "alloy-rlp",
  "backon",
  "clap 4.5.41",
@@ -10022,6 +10009,7 @@ dependencies = [
  "reth-discv5",
  "reth-downloaders",
  "reth-ecies",
+ "reth-era",
  "reth-era-downloader",
  "reth-era-utils",
  "reth-eth-wire",
@@ -10041,6 +10029,7 @@ dependencies = [
  "reth-primitives-traits",
  "reth-provider",
  "reth-prune",
+ "reth-revm",
  "reth-stages",
  "reth-static-file",
  "reth-static-file-types",
@@ -10058,8 +10047,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-runner"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -10068,11 +10057,11 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-util"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-eips 1.0.20",
- "alloy-primitives 1.2.1",
+ "alloy-eips 1.0.23",
+ "alloy-primitives 1.3.0",
  "cfg-if",
  "eyre",
  "libc",
@@ -10086,13 +10075,13 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-consensus 1.0.20",
- "alloy-eips 1.0.20",
+ "alloy-consensus 1.0.23",
+ "alloy-eips 1.0.23",
  "alloy-genesis",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.0",
  "alloy-trie 0.9.0",
  "arbitrary",
  "bytes",
@@ -10106,8 +10095,8 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
  "convert_case 0.7.1",
  "proc-macro2 1.0.95",
@@ -10117,8 +10106,8 @@ dependencies = [
 
 [[package]]
 name = "reth-config"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -10132,11 +10121,11 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-consensus 1.0.20",
- "alloy-primitives 1.2.1",
+ "alloy-consensus 1.0.23",
+ "alloy-primitives 1.3.0",
  "auto_impl",
  "reth-execution-types",
  "reth-primitives-traits",
@@ -10145,11 +10134,11 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-consensus 1.0.20",
- "alloy-eips 1.0.20",
+ "alloy-consensus 1.0.23",
+ "alloy-eips 1.0.23",
  "reth-chainspec",
  "reth-consensus",
  "reth-primitives-traits",
@@ -10157,13 +10146,13 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-debug-client"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-consensus 1.0.20",
- "alloy-eips 1.0.20",
- "alloy-json-rpc 1.0.20",
- "alloy-primitives 1.2.1",
+ "alloy-consensus 1.0.23",
+ "alloy-eips 1.0.23",
+ "alloy-json-rpc 1.0.23",
+ "alloy-primitives 1.3.0",
  "alloy-provider",
  "alloy-rpc-types-engine",
  "auto_impl",
@@ -10176,15 +10165,16 @@ dependencies = [
  "reth-tracing",
  "ringbuffer",
  "serde",
+ "serde_json",
  "tokio",
 ]
 
 [[package]]
 name = "reth-db"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.0",
  "derive_more 2.0.1",
  "eyre",
  "metrics",
@@ -10199,7 +10189,7 @@ dependencies = [
  "reth-storage-errors",
  "reth-tracing",
  "rustc-hash 2.1.1",
- "strum 0.27.1",
+ "strum 0.27.2",
  "sysinfo 0.33.1",
  "tempfile",
  "thiserror 2.0.12",
@@ -10207,12 +10197,12 @@ dependencies = [
 
 [[package]]
 name = "reth-db-api"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-consensus 1.0.20",
+ "alloy-consensus 1.0.23",
  "alloy-genesis",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.0",
  "arbitrary",
  "bytes",
  "derive_more 2.0.1",
@@ -10235,12 +10225,12 @@ dependencies = [
 
 [[package]]
 name = "reth-db-common"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-consensus 1.0.20",
+ "alloy-consensus 1.0.23",
  "alloy-genesis",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.0",
  "boyer-moore-magiclen",
  "eyre",
  "reth-chainspec",
@@ -10264,11 +10254,11 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-eips 1.0.20",
- "alloy-primitives 1.2.1",
+ "alloy-eips 1.0.23",
+ "alloy-primitives 1.3.0",
  "arbitrary",
  "bytes",
  "modular-bitfield",
@@ -10279,10 +10269,10 @@ dependencies = [
 
 [[package]]
 name = "reth-discv4"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.0",
  "alloy-rlp",
  "discv5",
  "enr 0.13.0",
@@ -10305,10 +10295,10 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.0",
  "alloy-rlp",
  "derive_more 2.0.1",
  "discv5",
@@ -10316,7 +10306,7 @@ dependencies = [
  "futures",
  "itertools 0.14.0",
  "metrics",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reth-chainspec",
  "reth-ethereum-forks",
  "reth-metrics",
@@ -10329,10 +10319,10 @@ dependencies = [
 
 [[package]]
 name = "reth-dns-discovery"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.0",
  "data-encoding",
  "enr 0.13.0",
  "hickory-resolver",
@@ -10353,12 +10343,12 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-consensus 1.0.20",
- "alloy-eips 1.0.20",
- "alloy-primitives 1.2.1",
+ "alloy-consensus 1.0.23",
+ "alloy-eips 1.0.23",
+ "alloy-primitives 1.3.0",
  "alloy-rlp",
  "futures",
  "futures-util",
@@ -10383,11 +10373,11 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
  "aes",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.0",
  "alloy-rlp",
  "block-padding",
  "byteorder",
@@ -10414,11 +10404,11 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-local"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-consensus 1.0.20",
- "alloy-primitives 1.2.1",
+ "alloy-consensus 1.0.23",
+ "alloy-primitives 1.3.0",
  "alloy-rpc-types-engine",
  "eyre",
  "futures-util",
@@ -10436,12 +10426,12 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-consensus 1.0.20",
- "alloy-eips 1.0.20",
- "alloy-primitives 1.2.1",
+ "alloy-consensus 1.0.23",
+ "alloy-eips 1.0.23",
+ "alloy-primitives 1.3.0",
  "alloy-rpc-types-engine",
  "auto_impl",
  "futures",
@@ -10461,8 +10451,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-service"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
  "futures",
  "pin-project",
@@ -10484,13 +10474,13 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-tree"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-consensus 1.0.20",
- "alloy-eips 1.0.20",
+ "alloy-consensus 1.0.23",
+ "alloy-eips 1.0.23",
  "alloy-evm",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.0",
  "alloy-rlp",
  "alloy-rpc-types-engine",
  "derive_more 2.0.1",
@@ -10521,6 +10511,7 @@ dependencies = [
  "reth-trie-db",
  "reth-trie-parallel",
  "reth-trie-sparse",
+ "reth-trie-sparse-parallel",
  "revm",
  "revm-primitives",
  "schnellru",
@@ -10531,10 +10522,10 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-util"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-consensus 1.0.20",
+ "alloy-consensus 1.0.23",
  "alloy-rpc-types-engine",
  "eyre",
  "futures",
@@ -10558,12 +10549,12 @@ dependencies = [
 
 [[package]]
 name = "reth-era"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-consensus 1.0.20",
- "alloy-eips 1.0.20",
- "alloy-primitives 1.2.1",
+ "alloy-consensus 1.0.23",
+ "alloy-eips 1.0.23",
+ "alloy-primitives 1.3.0",
  "alloy-rlp",
  "ethereum_ssz 0.9.0",
  "ethereum_ssz_derive 0.9.0",
@@ -10574,10 +10565,10 @@ dependencies = [
 
 [[package]]
 name = "reth-era-downloader"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.0",
  "bytes",
  "eyre",
  "futures-util",
@@ -10589,11 +10580,11 @@ dependencies = [
 
 [[package]]
 name = "reth-era-utils"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-consensus 1.0.20",
- "alloy-primitives 1.2.1",
+ "alloy-consensus 1.0.23",
+ "alloy-primitives 1.3.0",
  "alloy-rlp",
  "eyre",
  "futures-util",
@@ -10613,8 +10604,8 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -10624,11 +10615,11 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
  "alloy-chains",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.0",
  "alloy-rlp",
  "bytes",
  "derive_more 2.0.1",
@@ -10652,14 +10643,14 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
  "alloy-chains",
- "alloy-consensus 1.0.20",
- "alloy-eips 1.0.20",
+ "alloy-consensus 1.0.23",
+ "alloy-eips 1.0.23",
  "alloy-hardforks",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.0",
  "alloy-rlp",
  "bytes",
  "derive_more 2.0.1",
@@ -10673,71 +10664,34 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-cli"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-consensus 1.0.20",
- "alloy-eips 1.0.20",
- "alloy-primitives 1.2.1",
- "alloy-rlp",
- "alloy-rpc-types",
- "backon",
+ "alloy-consensus 1.0.23",
  "clap 4.5.41",
  "eyre",
- "futures",
- "reth-basic-payload-builder",
  "reth-chainspec",
  "reth-cli",
  "reth-cli-commands",
  "reth-cli-runner",
- "reth-cli-util",
- "reth-config",
- "reth-consensus",
  "reth-db",
- "reth-db-api",
- "reth-downloaders",
- "reth-errors",
- "reth-ethereum-payload-builder",
- "reth-ethereum-primitives",
- "reth-evm",
- "reth-execution-types",
- "reth-exex",
- "reth-fs-util",
- "reth-network",
- "reth-network-api",
- "reth-network-p2p",
  "reth-node-api",
  "reth-node-builder",
  "reth-node-core",
  "reth-node-ethereum",
- "reth-node-events",
  "reth-node-metrics",
- "reth-payload-builder",
- "reth-primitives-traits",
- "reth-provider",
- "reth-prune",
- "reth-revm",
- "reth-stages",
- "reth-static-file",
- "reth-tasks",
  "reth-tracing",
- "reth-transaction-pool",
- "reth-trie",
- "reth-trie-db",
- "serde_json",
- "similar-asserts",
- "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-consensus 1.0.20",
- "alloy-eips 1.0.20",
- "alloy-primitives 1.2.1",
+ "alloy-consensus 1.0.23",
+ "alloy-eips 1.0.23",
+ "alloy-primitives 1.3.0",
  "reth-chainspec",
  "reth-consensus",
  "reth-consensus-common",
@@ -10748,11 +10702,11 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-eips 1.0.20",
- "alloy-primitives 1.2.1",
+ "alloy-eips 1.0.23",
+ "alloy-primitives 1.3.0",
  "alloy-rlp",
  "alloy-rpc-types-engine",
  "reth-engine-primitives",
@@ -10766,12 +10720,12 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
  "alloy-eip2124 0.2.0",
  "alloy-hardforks",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.0",
  "auto_impl",
  "once_cell",
  "rustc-hash 2.1.1",
@@ -10779,12 +10733,12 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-consensus 1.0.20",
- "alloy-eips 1.0.20",
- "alloy-primitives 1.2.1",
+ "alloy-consensus 1.0.23",
+ "alloy-eips 1.0.23",
+ "alloy-primitives 1.3.0",
  "alloy-rlp",
  "alloy-rpc-types-engine",
  "reth-basic-payload-builder",
@@ -10808,12 +10762,12 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-consensus 1.0.20",
- "alloy-eips 1.0.20",
- "alloy-primitives 1.2.1",
+ "alloy-consensus 1.0.23",
+ "alloy-eips 1.0.23",
+ "alloy-primitives 1.3.0",
  "alloy-rlp",
  "arbitrary",
  "modular-bitfield",
@@ -10826,8 +10780,8 @@ dependencies = [
 
 [[package]]
 name = "reth-etl"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -10836,13 +10790,13 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-consensus 1.0.20",
- "alloy-eips 1.0.20",
+ "alloy-consensus 1.0.23",
+ "alloy-eips 1.0.23",
  "alloy-evm",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.0",
  "auto_impl",
  "derive_more 2.0.1",
  "futures-util",
@@ -10859,13 +10813,13 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-consensus 1.0.20",
- "alloy-eips 1.0.20",
+ "alloy-consensus 1.0.23",
+ "alloy-eips 1.0.23",
  "alloy-evm",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.0",
  "derive_more 2.0.1",
  "reth-chainspec",
  "reth-ethereum-forks",
@@ -10878,11 +10832,11 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
  "alloy-evm",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.0",
  "alloy-rlp",
  "nybbles 0.4.1",
  "reth-storage-errors",
@@ -10891,13 +10845,13 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-consensus 1.0.20",
- "alloy-eips 1.0.20",
+ "alloy-consensus 1.0.23",
+ "alloy-eips 1.0.23",
  "alloy-evm",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.0",
  "derive_more 2.0.1",
  "reth-ethereum-primitives",
  "reth-primitives-traits",
@@ -10909,12 +10863,12 @@ dependencies = [
 
 [[package]]
 name = "reth-exex"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-consensus 1.0.20",
- "alloy-eips 1.0.20",
- "alloy-primitives 1.2.1",
+ "alloy-consensus 1.0.23",
+ "alloy-eips 1.0.23",
+ "alloy-primitives 1.3.0",
  "eyre",
  "futures",
  "itertools 0.14.0",
@@ -10947,11 +10901,11 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-types"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-eips 1.0.20",
- "alloy-primitives 1.2.1",
+ "alloy-eips 1.0.23",
+ "alloy-primitives 1.3.0",
  "reth-chain-state",
  "reth-execution-types",
  "reth-primitives-traits",
@@ -10961,8 +10915,8 @@ dependencies = [
 
 [[package]]
 name = "reth-fs-util"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
  "serde",
  "serde_json",
@@ -10971,11 +10925,11 @@ dependencies = [
 
 [[package]]
 name = "reth-invalid-block-hooks"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-consensus 1.0.20",
- "alloy-primitives 1.2.1",
+ "alloy-consensus 1.0.23",
+ "alloy-primitives 1.3.0",
  "alloy-rlp",
  "alloy-rpc-types-debug",
  "eyre",
@@ -10999,8 +10953,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ipc"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
  "bytes",
  "futures",
@@ -11019,8 +10973,8 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
  "bitflags 2.9.1",
  "byteorder",
@@ -11036,8 +10990,8 @@ dependencies = [
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
  "bindgen",
  "cc",
@@ -11045,8 +10999,8 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
  "futures",
  "metrics",
@@ -11057,16 +11011,16 @@ dependencies = [
 
 [[package]]
 name = "reth-net-banlist"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.0",
 ]
 
 [[package]]
 name = "reth-net-nat"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -11079,12 +11033,12 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-consensus 1.0.20",
- "alloy-eips 1.0.20",
- "alloy-primitives 1.2.1",
+ "alloy-consensus 1.0.23",
+ "alloy-eips 1.0.23",
+ "alloy-primitives 1.3.0",
  "alloy-rlp",
  "aquamarine",
  "auto_impl",
@@ -11097,7 +11051,7 @@ dependencies = [
  "parking_lot",
  "pin-project",
  "rand 0.8.5",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reth-chainspec",
  "reth-consensus",
  "reth-discv4",
@@ -11134,11 +11088,13 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-primitives 1.2.1",
+ "alloy-consensus 1.0.23",
+ "alloy-primitives 1.3.0",
  "alloy-rpc-types-admin",
+ "alloy-rpc-types-eth 1.0.23",
  "auto_impl",
  "derive_more 2.0.1",
  "enr 0.13.0",
@@ -11157,12 +11113,12 @@ dependencies = [
 
 [[package]]
 name = "reth-network-p2p"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-consensus 1.0.20",
- "alloy-eips 1.0.20",
- "alloy-primitives 1.2.1",
+ "alloy-consensus 1.0.23",
+ "alloy-eips 1.0.23",
+ "alloy-primitives 1.3.0",
  "auto_impl",
  "derive_more 2.0.1",
  "futures",
@@ -11179,10 +11135,10 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.0",
  "alloy-rlp",
  "enr 0.13.0",
  "secp256k1 0.30.0",
@@ -11194,8 +11150,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
  "alloy-eip2124 0.2.0",
  "humantime-serde",
@@ -11208,8 +11164,8 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
  "anyhow",
  "bincode",
@@ -11225,8 +11181,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -11249,12 +11205,12 @@ dependencies = [
 
 [[package]]
 name = "reth-node-builder"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-consensus 1.0.20",
- "alloy-eips 1.0.20",
- "alloy-primitives 1.2.1",
+ "alloy-consensus 1.0.23",
+ "alloy-eips 1.0.23",
+ "alloy-primitives 1.3.0",
  "alloy-provider",
  "alloy-rpc-types",
  "alloy-rpc-types-engine",
@@ -11287,6 +11243,7 @@ dependencies = [
  "reth-network-p2p",
  "reth-node-api",
  "reth-node-core",
+ "reth-node-ethstats",
  "reth-node-events",
  "reth-node-metrics",
  "reth-payload-builder",
@@ -11313,12 +11270,12 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-consensus 1.0.20",
- "alloy-eips 1.0.20",
- "alloy-primitives 1.2.1",
+ "alloy-consensus 1.0.23",
+ "alloy-eips 1.0.23",
+ "alloy-primitives 1.3.0",
  "alloy-rpc-types-engine",
  "clap 4.5.41",
  "derive_more 2.0.1",
@@ -11326,7 +11283,7 @@ dependencies = [
  "eyre",
  "futures",
  "humantime",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reth-chainspec",
  "reth-cli-util",
  "reth-config",
@@ -11334,6 +11291,7 @@ dependencies = [
  "reth-db",
  "reth-discv4",
  "reth-discv5",
+ "reth-engine-local",
  "reth-engine-primitives",
  "reth-ethereum-forks",
  "reth-net-nat",
@@ -11353,7 +11311,7 @@ dependencies = [
  "secp256k1 0.30.0",
  "serde",
  "shellexpand",
- "strum 0.27.1",
+ "strum 0.27.2",
  "thiserror 2.0.12",
  "toml 0.8.23",
  "tracing",
@@ -11364,15 +11322,16 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethereum"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-eips 1.0.20",
+ "alloy-eips 1.0.23",
+ "alloy-network",
  "alloy-rpc-types-engine",
- "alloy-rpc-types-eth 1.0.20",
+ "alloy-rpc-types-eth 1.0.23",
  "eyre",
  "reth-chainspec",
- "reth-consensus",
+ "reth-engine-local",
  "reth-engine-primitives",
  "reth-ethereum-consensus",
  "reth-ethereum-engine-primitives",
@@ -11390,6 +11349,7 @@ dependencies = [
  "reth-rpc",
  "reth-rpc-api",
  "reth-rpc-builder",
+ "reth-rpc-eth-api",
  "reth-rpc-eth-types",
  "reth-rpc-server-types",
  "reth-tracing",
@@ -11399,13 +11359,37 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-node-events"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+name = "reth-node-ethstats"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-consensus 1.0.20",
- "alloy-eips 1.0.20",
- "alloy-primitives 1.2.1",
+ "alloy-consensus 1.0.23",
+ "alloy-primitives 1.3.0",
+ "chrono",
+ "futures-util",
+ "reth-chain-state",
+ "reth-network-api",
+ "reth-primitives-traits",
+ "reth-storage-api",
+ "reth-transaction-pool",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
+ "tokio",
+ "tokio-stream",
+ "tokio-tungstenite 0.26.2",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "reth-node-events"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
+dependencies = [
+ "alloy-consensus 1.0.23",
+ "alloy-eips 1.0.23",
+ "alloy-primitives 1.3.0",
  "alloy-rpc-types-engine",
  "derive_more 2.0.1",
  "futures",
@@ -11424,8 +11408,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-metrics"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
  "eyre",
  "http 1.3.1",
@@ -11445,8 +11429,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-types"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -11458,12 +11442,12 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-primitives"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-consensus 1.0.20",
- "alloy-eips 1.0.20",
- "alloy-primitives 1.2.1",
+ "alloy-consensus 1.0.23",
+ "alloy-eips 1.0.23",
+ "alloy-primitives 1.3.0",
  "alloy-rlp",
  "arbitrary",
  "bytes",
@@ -11477,10 +11461,10 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-consensus 1.0.20",
+ "alloy-consensus 1.0.23",
  "alloy-rpc-types",
  "futures-util",
  "metrics",
@@ -11497,8 +11481,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder-primitives"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -11509,11 +11493,11 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-eips 1.0.20",
- "alloy-primitives 1.2.1",
+ "alloy-eips 1.0.23",
+ "alloy-primitives 1.3.0",
  "alloy-rpc-types-engine",
  "auto_impl",
  "op-alloy-rpc-types-engine",
@@ -11528,20 +11512,20 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-consensus 1.0.20",
+ "alloy-consensus 1.0.23",
  "alloy-rpc-types-engine",
  "reth-primitives-traits",
 ]
 
 [[package]]
 name = "reth-primitives"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-consensus 1.0.20",
+ "alloy-consensus 1.0.23",
  "c-kzg",
  "once_cell",
  "reth-ethereum-forks",
@@ -11552,15 +11536,15 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-consensus 1.0.20",
- "alloy-eips 1.0.20",
+ "alloy-consensus 1.0.23",
+ "alloy-eips 1.0.23",
  "alloy-genesis",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.0",
  "alloy-rlp",
- "alloy-rpc-types-eth 1.0.20",
+ "alloy-rpc-types-eth 1.0.23",
  "alloy-trie 0.9.0",
  "arbitrary",
  "auto_impl",
@@ -11585,12 +11569,12 @@ dependencies = [
 
 [[package]]
 name = "reth-provider"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-consensus 1.0.20",
- "alloy-eips 1.0.20",
- "alloy-primitives 1.2.1",
+ "alloy-consensus 1.0.23",
+ "alloy-eips 1.0.23",
+ "alloy-primitives 1.3.0",
  "alloy-rpc-types-engine",
  "dashmap 6.1.0",
  "eyre",
@@ -11623,19 +11607,19 @@ dependencies = [
  "reth-trie-db",
  "revm-database",
  "revm-state",
- "strum 0.27.1",
+ "strum 0.27.2",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "reth-prune"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-consensus 1.0.20",
- "alloy-eips 1.0.20",
- "alloy-primitives 1.2.1",
+ "alloy-consensus 1.0.23",
+ "alloy-eips 1.0.23",
+ "alloy-primitives 1.3.0",
  "itertools 0.14.0",
  "metrics",
  "rayon",
@@ -11658,10 +11642,10 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.0",
  "arbitrary",
  "derive_more 2.0.1",
  "modular-bitfield",
@@ -11691,11 +11675,11 @@ dependencies = [
 
 [[package]]
 name = "reth-ress-protocol"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-consensus 1.0.20",
- "alloy-primitives 1.2.1",
+ "alloy-consensus 1.0.23",
+ "alloy-primitives 1.3.0",
  "alloy-rlp",
  "futures",
  "reth-eth-wire",
@@ -11710,11 +11694,11 @@ dependencies = [
 
 [[package]]
 name = "reth-ress-provider"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-consensus 1.0.20",
- "alloy-primitives 1.2.1",
+ "alloy-consensus 1.0.23",
+ "alloy-primitives 1.3.0",
  "eyre",
  "futures",
  "parking_lot",
@@ -11737,10 +11721,10 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.0",
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-storage-errors",
@@ -11750,27 +11734,27 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-consensus 1.0.20",
+ "alloy-consensus 1.0.23",
  "alloy-dyn-abi",
- "alloy-eips 1.0.20",
+ "alloy-eips 1.0.23",
  "alloy-evm",
  "alloy-genesis",
  "alloy-network",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.0",
  "alloy-rlp",
  "alloy-rpc-types",
  "alloy-rpc-types-admin",
  "alloy-rpc-types-beacon",
  "alloy-rpc-types-debug",
  "alloy-rpc-types-engine",
- "alloy-rpc-types-eth 1.0.20",
+ "alloy-rpc-types-eth 1.0.23",
  "alloy-rpc-types-mev",
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
- "alloy-serde 1.0.20",
+ "alloy-serde 1.0.23",
  "alloy-signer",
  "alloy-signer-local",
  "async-trait",
@@ -11779,6 +11763,7 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "hyper 1.6.0",
+ "itertools 0.14.0",
  "jsonrpsee 0.25.1",
  "jsonrpsee-types 0.25.1",
  "jsonwebtoken 9.3.1",
@@ -11789,7 +11774,6 @@ dependencies = [
  "reth-consensus",
  "reth-engine-primitives",
  "reth-errors",
- "reth-ethereum-primitives",
  "reth-evm",
  "reth-evm-ethereum",
  "reth-execution-types",
@@ -11811,7 +11795,7 @@ dependencies = [
  "reth-transaction-pool",
  "reth-trie-common",
  "revm",
- "revm-inspectors",
+ "revm-inspectors 0.27.1",
  "revm-primitives",
  "serde",
  "serde_json",
@@ -11826,24 +11810,24 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-eips 1.0.20",
+ "alloy-eips 1.0.23",
  "alloy-genesis",
- "alloy-json-rpc 1.0.20",
- "alloy-primitives 1.2.1",
+ "alloy-json-rpc 1.0.23",
+ "alloy-primitives 1.3.0",
  "alloy-rpc-types",
  "alloy-rpc-types-admin",
  "alloy-rpc-types-anvil",
  "alloy-rpc-types-beacon",
  "alloy-rpc-types-debug",
  "alloy-rpc-types-engine",
- "alloy-rpc-types-eth 1.0.20",
+ "alloy-rpc-types-eth 1.0.23",
  "alloy-rpc-types-mev",
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
- "alloy-serde 1.0.20",
+ "alloy-serde 1.0.23",
  "jsonrpsee 0.25.1",
  "reth-chain-state",
  "reth-engine-primitives",
@@ -11854,8 +11838,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-builder"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -11892,15 +11876,17 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-convert"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-consensus 1.0.20",
- "alloy-json-rpc 1.0.20",
+ "alloy-consensus 1.0.23",
+ "alloy-json-rpc 1.0.23",
  "alloy-network",
- "alloy-primitives 1.2.1",
- "alloy-rpc-types-eth 1.0.20",
+ "alloy-primitives 1.3.0",
+ "alloy-rpc-types-eth 1.0.23",
+ "alloy-signer",
  "jsonrpsee-types 0.25.1",
+ "reth-ethereum-primitives",
  "reth-evm",
  "reth-primitives-traits",
  "revm-context",
@@ -11909,11 +11895,11 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-engine-api"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-eips 1.0.20",
- "alloy-primitives 1.2.1",
+ "alloy-eips 1.0.23",
+ "alloy-primitives 1.3.0",
  "alloy-rpc-types-engine",
  "async-trait",
  "jsonrpsee-core 0.25.1",
@@ -11939,20 +11925,20 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-api"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-consensus 1.0.20",
+ "alloy-consensus 1.0.23",
  "alloy-dyn-abi",
- "alloy-eips 1.0.20",
+ "alloy-eips 1.0.23",
  "alloy-evm",
- "alloy-json-rpc 1.0.20",
+ "alloy-json-rpc 1.0.23",
  "alloy-network",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.0",
  "alloy-rlp",
- "alloy-rpc-types-eth 1.0.20",
+ "alloy-rpc-types-eth 1.0.23",
  "alloy-rpc-types-mev",
- "alloy-serde 1.0.20",
+ "alloy-serde 1.0.23",
  "async-trait",
  "auto_impl",
  "dyn-clone",
@@ -11966,7 +11952,6 @@ dependencies = [
  "reth-evm",
  "reth-network-api",
  "reth-node-api",
- "reth-payload-builder",
  "reth-primitives-traits",
  "reth-revm",
  "reth-rpc-convert",
@@ -11977,29 +11962,30 @@ dependencies = [
  "reth-transaction-pool",
  "reth-trie-common",
  "revm",
- "revm-inspectors",
+ "revm-inspectors 0.27.1",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "reth-rpc-eth-types"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-consensus 1.0.20",
- "alloy-eips 1.0.20",
+ "alloy-consensus 1.0.23",
+ "alloy-eips 1.0.23",
  "alloy-evm",
- "alloy-primitives 1.2.1",
- "alloy-rpc-types-eth 1.0.20",
- "alloy-sol-types 1.2.1",
+ "alloy-network",
+ "alloy-primitives 1.3.0",
+ "alloy-rpc-types-eth 1.0.23",
+ "alloy-sol-types 1.3.0",
  "derive_more 2.0.1",
  "futures",
  "itertools 0.14.0",
  "jsonrpsee-core 0.25.1",
  "jsonrpsee-types 0.25.1",
  "metrics",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reth-chain-state",
  "reth-chainspec",
  "reth-errors",
@@ -12016,7 +12002,7 @@ dependencies = [
  "reth-transaction-pool",
  "reth-trie",
  "revm",
- "revm-inspectors",
+ "revm-inspectors 0.27.1",
  "schnellru",
  "serde",
  "thiserror 2.0.12",
@@ -12027,8 +12013,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-layer"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.3.1",
@@ -12041,28 +12027,28 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-eips 1.0.20",
- "alloy-primitives 1.2.1",
+ "alloy-eips 1.0.23",
+ "alloy-primitives 1.3.0",
  "alloy-rpc-types-engine",
  "jsonrpsee-core 0.25.1",
  "jsonrpsee-types 0.25.1",
  "reth-errors",
  "reth-network-api",
  "serde",
- "strum 0.27.1",
+ "strum 0.27.2",
 ]
 
 [[package]]
 name = "reth-stages"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-consensus 1.0.20",
- "alloy-eips 1.0.20",
- "alloy-primitives 1.2.1",
+ "alloy-consensus 1.0.23",
+ "alloy-eips 1.0.23",
+ "alloy-primitives 1.3.0",
  "bincode",
  "blake3",
  "eyre",
@@ -12103,11 +12089,11 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-api"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-eips 1.0.20",
- "alloy-primitives 1.2.1",
+ "alloy-eips 1.0.23",
+ "alloy-primitives 1.3.0",
  "aquamarine",
  "auto_impl",
  "futures-util",
@@ -12130,10 +12116,10 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.0",
  "arbitrary",
  "bytes",
  "modular-bitfield",
@@ -12144,10 +12130,10 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.0",
  "parking_lot",
  "rayon",
  "reth-codecs",
@@ -12164,24 +12150,24 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.0",
  "clap 4.5.41",
  "derive_more 2.0.1",
  "serde",
- "strum 0.27.1",
+ "strum 0.27.2",
 ]
 
 [[package]]
 name = "reth-storage-api"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-consensus 1.0.20",
- "alloy-eips 1.0.20",
- "alloy-primitives 1.2.1",
+ "alloy-consensus 1.0.23",
+ "alloy-eips 1.0.23",
+ "alloy-primitives 1.3.0",
  "alloy-rpc-types-engine",
  "auto_impl",
  "reth-chainspec",
@@ -12200,11 +12186,11 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-eips 1.0.20",
- "alloy-primitives 1.2.1",
+ "alloy-eips 1.0.23",
+ "alloy-primitives 1.3.0",
  "alloy-rlp",
  "derive_more 2.0.1",
  "reth-primitives-traits",
@@ -12216,8 +12202,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tasks"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -12234,8 +12220,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -12244,8 +12230,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
  "clap 4.5.41",
  "eyre",
@@ -12259,12 +12245,12 @@ dependencies = [
 
 [[package]]
 name = "reth-transaction-pool"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-consensus 1.0.20",
- "alloy-eips 1.0.20",
- "alloy-primitives 1.2.1",
+ "alloy-consensus 1.0.23",
+ "alloy-eips 1.0.23",
+ "alloy-primitives 1.3.0",
  "alloy-rlp",
  "aquamarine",
  "auto_impl",
@@ -12272,7 +12258,7 @@ dependencies = [
  "futures-util",
  "metrics",
  "parking_lot",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reth-chain-state",
  "reth-chainspec",
  "reth-eth-wire-types",
@@ -12297,12 +12283,12 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-consensus 1.0.20",
- "alloy-eips 1.0.20",
- "alloy-primitives 1.2.1",
+ "alloy-consensus 1.0.23",
+ "alloy-eips 1.0.23",
+ "alloy-primitives 1.3.0",
  "alloy-rlp",
  "alloy-trie 0.9.0",
  "auto_impl",
@@ -12322,14 +12308,14 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-consensus 1.0.20",
- "alloy-primitives 1.2.1",
+ "alloy-consensus 1.0.23",
+ "alloy-primitives 1.3.0",
  "alloy-rlp",
- "alloy-rpc-types-eth 1.0.20",
- "alloy-serde 1.0.20",
+ "alloy-rpc-types-eth 1.0.23",
+ "alloy-serde 1.0.23",
  "alloy-trie 0.9.0",
  "arbitrary",
  "bytes",
@@ -12348,10 +12334,10 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-db"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.0",
  "reth-db-api",
  "reth-execution-errors",
  "reth-primitives-traits",
@@ -12361,10 +12347,10 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-parallel"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.0",
  "alloy-rlp",
  "derive_more 2.0.1",
  "itertools 0.14.0",
@@ -12386,10 +12372,10 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.0",
  "alloy-rlp",
  "alloy-trie 0.9.0",
  "auto_impl",
@@ -12403,17 +12389,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-trie-sparse-parallel"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
+dependencies = [
+ "alloy-primitives 1.3.0",
+ "alloy-rlp",
+ "alloy-trie 0.9.0",
+ "rayon",
+ "reth-execution-errors",
+ "reth-trie-common",
+ "reth-trie-sparse",
+ "smallvec",
+ "tracing",
+]
+
+[[package]]
 name = "reth-zstd-compressors"
-version = "1.5.0"
-source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?branch=fusaka-devnet-3#8402695f5e48d249d3d178c84b717b6d1693cc85"
 dependencies = [
  "zstd 0.13.3",
 ]
 
 [[package]]
 name = "revm"
-version = "27.0.2"
-source = "git+https://github.com/bluealloy/revm?branch=rakita%2Feip7907#37edc381a940a52abb90b3e0a480292a675e8129"
+version = "27.0.3"
+source = "git+https://github.com/bluealloy/revm?branch=fusaka-devnet-3#d5292dda70a21784d1cf9fcfca957445376e91f0"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -12431,7 +12433,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "6.0.1"
-source = "git+https://github.com/bluealloy/revm?branch=rakita%2Feip7907#37edc381a940a52abb90b3e0a480292a675e8129"
+source = "git+https://github.com/bluealloy/revm?branch=fusaka-devnet-3#d5292dda70a21784d1cf9fcfca957445376e91f0"
 dependencies = [
  "bitvec",
  "once_cell",
@@ -12442,8 +12444,8 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "8.0.2"
-source = "git+https://github.com/bluealloy/revm?branch=rakita%2Feip7907#37edc381a940a52abb90b3e0a480292a675e8129"
+version = "8.0.3"
+source = "git+https://github.com/bluealloy/revm?branch=fusaka-devnet-3#d5292dda70a21784d1cf9fcfca957445376e91f0"
 dependencies = [
  "cfg-if",
  "derive-where",
@@ -12458,7 +12460,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "8.0.1"
-source = "git+https://github.com/bluealloy/revm?branch=rakita%2Feip7907#37edc381a940a52abb90b3e0a480292a675e8129"
+source = "git+https://github.com/bluealloy/revm?branch=fusaka-devnet-3#d5292dda70a21784d1cf9fcfca957445376e91f0"
 dependencies = [
  "alloy-eip2930 0.2.1",
  "alloy-eip7702 0.6.1",
@@ -12473,9 +12475,9 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "7.0.1"
-source = "git+https://github.com/bluealloy/revm?branch=rakita%2Feip7907#37edc381a940a52abb90b3e0a480292a675e8129"
+source = "git+https://github.com/bluealloy/revm?branch=fusaka-devnet-3#d5292dda70a21784d1cf9fcfca957445376e91f0"
 dependencies = [
- "alloy-eips 1.0.20",
+ "alloy-eips 1.0.23",
  "revm-bytecode",
  "revm-database-interface",
  "revm-primitives",
@@ -12486,7 +12488,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "7.0.1"
-source = "git+https://github.com/bluealloy/revm?branch=rakita%2Feip7907#37edc381a940a52abb90b3e0a480292a675e8129"
+source = "git+https://github.com/bluealloy/revm?branch=fusaka-devnet-3#d5292dda70a21784d1cf9fcfca957445376e91f0"
 dependencies = [
  "auto_impl",
  "either",
@@ -12497,8 +12499,8 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "8.0.2"
-source = "git+https://github.com/bluealloy/revm?branch=rakita%2Feip7907#37edc381a940a52abb90b3e0a480292a675e8129"
+version = "8.0.3"
+source = "git+https://github.com/bluealloy/revm?branch=fusaka-devnet-3#d5292dda70a21784d1cf9fcfca957445376e91f0"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -12515,8 +12517,8 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "8.0.2"
-source = "git+https://github.com/bluealloy/revm?branch=rakita%2Feip7907#37edc381a940a52abb90b3e0a480292a675e8129"
+version = "8.0.3"
+source = "git+https://github.com/bluealloy/revm?branch=fusaka-devnet-3#d5292dda70a21784d1cf9fcfca957445376e91f0"
 dependencies = [
  "auto_impl",
  "either",
@@ -12536,10 +12538,26 @@ version = "0.26.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7b99a2332cf8eed9e9a22fffbf76dfadc99d2c45de6ae6431a1eb9f657dd97a"
 dependencies = [
- "alloy-primitives 1.2.1",
- "alloy-rpc-types-eth 1.0.20",
+ "alloy-primitives 1.3.0",
+ "alloy-rpc-types-eth 1.0.23",
  "alloy-rpc-types-trace",
- "alloy-sol-types 1.2.1",
+ "alloy-sol-types 1.3.0",
+ "colorchoice",
+ "revm",
+ "serde_json",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "revm-inspectors"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aad27cab355b0aa905d0744f3222e716b40ad48b32276ac4b0a615f2c3364c97"
+dependencies = [
+ "alloy-primitives 1.3.0",
+ "alloy-rpc-types-eth 1.0.23",
+ "alloy-rpc-types-trace",
+ "alloy-sol-types 1.3.0",
  "anstyle",
  "boa_engine",
  "boa_gc",
@@ -12552,8 +12570,8 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "23.0.1"
-source = "git+https://github.com/bluealloy/revm?branch=rakita%2Feip7907#37edc381a940a52abb90b3e0a480292a675e8129"
+version = "23.0.2"
+source = "git+https://github.com/bluealloy/revm?branch=fusaka-devnet-3#d5292dda70a21784d1cf9fcfca957445376e91f0"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -12563,8 +12581,8 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "24.0.0"
-source = "git+https://github.com/bluealloy/revm?branch=rakita%2Feip7907#37edc381a940a52abb90b3e0a480292a675e8129"
+version = "24.0.1"
+source = "git+https://github.com/bluealloy/revm?branch=fusaka-devnet-3#d5292dda70a21784d1cf9fcfca957445376e91f0"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -12590,9 +12608,9 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "20.0.0"
-source = "git+https://github.com/bluealloy/revm?branch=rakita%2Feip7907#37edc381a940a52abb90b3e0a480292a675e8129"
+source = "git+https://github.com/bluealloy/revm?branch=fusaka-devnet-3#d5292dda70a21784d1cf9fcfca957445376e91f0"
 dependencies = [
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.0",
  "num_enum",
  "serde",
 ]
@@ -12600,7 +12618,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "7.0.1"
-source = "git+https://github.com/bluealloy/revm?branch=rakita%2Feip7907#37edc381a940a52abb90b3e0a480292a675e8129"
+source = "git+https://github.com/bluealloy/revm?branch=fusaka-devnet-3#d5292dda70a21784d1cf9fcfca957445376e91f0"
 dependencies = [
  "bitflags 2.9.1",
  "revm-bytecode",
@@ -12803,7 +12821,7 @@ dependencies = [
  "primitive-types",
  "proptest",
  "rand 0.8.5",
- "rand 0.9.1",
+ "rand 0.9.2",
  "rlp",
  "ruint-macro",
  "serde",
@@ -12912,15 +12930,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
  "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -13256,7 +13274,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c3c81b43dc2d8877c216a3fccf76677ee1ebccd429566d3e67447290d0c42b2"
 dependencies = [
  "bitcoin_hashes",
- "rand 0.9.1",
+ "rand 0.9.2",
  "secp256k1-sys 0.11.0",
 ]
 
@@ -13400,9 +13418,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
 dependencies = [
  "indexmap 2.10.0",
  "itoa",
@@ -13659,27 +13677,6 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
-
-[[package]]
-name = "similar"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
-dependencies = [
- "bstr",
- "unicode-segmentation",
-]
-
-[[package]]
-name = "similar-asserts"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b441962c817e33508847a22bd82f03a30cff43642dc2fae8b050566121eb9a"
-dependencies = [
- "console",
- "serde",
- "similar",
-]
 
 [[package]]
 name = "simple_asn1"
@@ -14226,11 +14223,11 @@ dependencies = [
 
 [[package]]
 name = "strum"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
- "strum_macros 0.27.1",
+ "strum_macros 0.27.2",
 ]
 
 [[package]]
@@ -14261,14 +14258,13 @@ dependencies = [
 
 [[package]]
 name = "strum_macros"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "rustversion",
  "syn 2.0.104",
 ]
 
@@ -14345,9 +14341,9 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ac494e7266fcdd2ad80bf4375d55d27a117ea5c866c26d0e97fe5b3caeeb75"
+checksum = "a7a985ff4ffd7373e10e0fb048110fb11a162e5a4c47f92ddb8787a6f766b769"
 dependencies = [
  "paste",
  "proc-macro2 1.0.95",
@@ -14425,7 +14421,7 @@ dependencies = [
 name = "sysperf"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.0",
  "num_cpus",
  "rand 0.8.5",
  "rayon",
@@ -14512,7 +14508,7 @@ dependencies = [
  "fastrand 2.3.0",
  "getrandom 0.3.3",
  "once_cell",
- "rustix 1.0.7",
+ "rustix 1.0.8",
  "windows-sys 0.59.0",
 ]
 
@@ -14558,9 +14554,9 @@ name = "test-relay"
 version = "0.1.0"
 dependencies = [
  "ahash",
- "alloy-consensus 1.0.20",
- "alloy-json-rpc 1.0.20",
- "alloy-primitives 1.2.1",
+ "alloy-consensus 1.0.23",
+ "alloy-json-rpc 1.0.23",
+ "alloy-primitives 1.3.0",
  "alloy-provider",
  "clap 4.5.41",
  "clap_builder",
@@ -14909,6 +14905,7 @@ dependencies = [
  "futures-util",
  "log",
  "rustls 0.23.29",
+ "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.2",
@@ -15110,8 +15107,6 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
- "futures",
- "futures-task",
  "pin-project",
  "tracing",
 ]
@@ -15207,7 +15202,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee44f4cef85f88b4dea21c0b1f58320bdf35715cf56d840969487cff00613321"
 dependencies = [
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.0",
  "ethereum_hashing 0.7.0",
  "ethereum_ssz 0.9.0",
  "smallvec",
@@ -15319,7 +15314,7 @@ dependencies = [
  "http 1.3.1",
  "httparse",
  "log",
- "rand 0.9.1",
+ "rand 0.9.2",
  "rustls 0.23.29",
  "rustls-pki-types",
  "sha1",
@@ -15870,14 +15865,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
 dependencies = [
- "webpki-root-certs 1.0.1",
+ "webpki-root-certs 1.0.2",
 ]
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86138b15b2b7d561bc4469e77027b8dd005a43dc502e9031d1f5afc8ce1f280e"
+checksum = "4e4ffd8df1c57e87c325000a3d6ef93db75279dc3a231125aac571650f22b12a"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -15894,14 +15889,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.1",
+ "webpki-roots 1.0.2",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8782dd5a41a24eed3a4f40b606249b3e236ca61adf1f25ea4d45c73de122b502"
+checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -16572,7 +16567,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af3a19837351dc82ba89f8a125e22a3c475f05aba604acc023d62b2739ae2909"
 dependencies = [
  "libc",
- "rustix 1.0.7",
+ "rustix 1.0.8",
 ]
 
 [[package]]
@@ -16854,5 +16849,5 @@ dependencies = [
 
 [[patch.unused]]
 name = "alloy-contract"
-version = "1.0.20"
-source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#000b830535a0b4d6374bc09727e3663fb6af9b89"
+version = "1.0.23"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka-devnet-3#3b877aca44f8d410226d3250b3ce53bcc077642b"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,9 +23,9 @@ dependencies = [
 
 [[package]]
 name = "adler2"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aead"
@@ -64,15 +64,15 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom 0.2.15",
+ "getrandom 0.3.3",
  "once_cell",
  "version_check 0.9.5",
- "zerocopy 0.7.35",
+ "zerocopy",
 ]
 
 [[package]]
@@ -107,11 +107,11 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy-chains"
-version = "0.2.0"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7734aecfc58a597dde036e4c5cace2ae43e2f8bf3d406b022a1ef34da178dd49"
+checksum = "5674914c2cfdb866c21cb0c09d82374ee39a1395cf512e7515f4c014083b3fff"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.2.1",
  "alloy-rlp",
  "num_enum",
  "serde",
@@ -143,15 +143,15 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad451f9a70c341d951bca4e811d74dbe1e193897acd17e9dbac1353698cc430b"
+version = "1.0.20"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#000b830535a0b4d6374bc09727e3663fb6af9b89"
 dependencies = [
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-eips 1.0.20",
+ "alloy-primitives 1.2.1",
  "alloy-rlp",
- "alloy-serde 1.0.9",
- "alloy-trie 0.8.1",
+ "alloy-serde 1.0.20",
+ "alloy-trie 0.9.0",
+ "alloy-tx-macros",
  "arbitrary",
  "auto_impl",
  "c-kzg",
@@ -160,7 +160,7 @@ dependencies = [
  "k256 0.13.4",
  "once_cell",
  "rand 0.8.5",
- "secp256k1",
+ "secp256k1 0.30.0",
  "serde",
  "serde_with",
  "thiserror 2.0.12",
@@ -182,29 +182,28 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142daffb15d5be1a2b20d2cd540edbcef03037b55d4ff69dc06beb4d06286dba"
+version = "1.0.20"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#000b830535a0b4d6374bc09727e3663fb6af9b89"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.20",
+ "alloy-eips 1.0.20",
+ "alloy-primitives 1.2.1",
  "alloy-rlp",
- "alloy-serde 1.0.9",
+ "alloy-serde 1.0.20",
  "arbitrary",
  "serde",
 ]
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9135eb501feccf7f4cb8a183afd406a65483fdad7bbd7332d0470e5d725c92f"
+checksum = "7b95b3deca680efc7e9cba781f1a1db352fa1ea50e6384a514944dcf4419e652"
 dependencies = [
- "alloy-json-abi 1.2.0",
- "alloy-primitives 1.2.0",
- "alloy-sol-type-parser 1.2.0",
- "alloy-sol-types 1.2.0",
+ "alloy-json-abi 1.2.1",
+ "alloy-primitives 1.2.1",
+ "alloy-sol-type-parser 1.2.1",
+ "alloy-sol-types 1.2.1",
  "derive_more 2.0.1",
  "itoa",
  "serde",
@@ -231,7 +230,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "741bdd7499908b3aa0b159bba11e71c8cddd009a2c2eb7a06e825f1ec87900a5"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.2.1",
  "alloy-rlp",
  "arbitrary",
  "crc",
@@ -257,7 +256,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b82752a889170df67bbb36d42ca63c531eb16274f0d7299ae2a680facba17bd"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.2.1",
  "alloy-rlp",
  "arbitrary",
  "rand 0.8.5",
@@ -282,7 +281,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d4769c6ffddca380b0070d71c8b7f30bed375543fe76bb2f74ec0acf4b7cd16"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.2.1",
  "alloy-rlp",
  "arbitrary",
  "k256 0.13.4",
@@ -309,21 +308,20 @@ dependencies = [
  "derive_more 2.0.1",
  "either",
  "serde",
- "sha2 0.10.8",
+ "sha2 0.10.9",
 ]
 
 [[package]]
 name = "alloy-eips"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3056872f6da48046913e76edb5ddced272861f6032f09461aea1a2497be5ae5d"
+version = "1.0.20"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#000b830535a0b4d6374bc09727e3663fb6af9b89"
 dependencies = [
  "alloy-eip2124 0.2.0",
  "alloy-eip2930 0.2.1",
  "alloy-eip7702 0.6.1",
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.2.1",
  "alloy-rlp",
- "alloy-serde 1.0.9",
+ "alloy-serde 1.0.20",
  "arbitrary",
  "auto_impl",
  "c-kzg",
@@ -332,20 +330,20 @@ dependencies = [
  "ethereum_ssz 0.9.0",
  "ethereum_ssz_derive 0.9.0",
  "serde",
- "sha2 0.10.8",
+ "sha2 0.10.9",
 ]
 
 [[package]]
 name = "alloy-evm"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "394b09cf3a32773eedf11828987f9c72dfa74545040be0422e3f5f09a2a3fab9"
+version = "0.13.0"
+source = "git+https://github.com/alloy-rs/evm?branch=fusaka%2Fdevnet2#0f1420656bd704de0ca066414013997a7c455c0d"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
+ "alloy-consensus 1.0.20",
+ "alloy-eips 1.0.20",
  "alloy-hardforks",
- "alloy-primitives 1.2.0",
- "alloy-sol-types 1.2.0",
+ "alloy-primitives 1.2.1",
+ "alloy-rpc-types-eth 1.0.20",
+ "alloy-sol-types 1.2.1",
  "auto_impl",
  "derive_more 2.0.1",
  "op-alloy-consensus",
@@ -356,26 +354,26 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c98fb40f07997529235cc474de814cd7bd9de561e101716289095696c0e4639d"
+version = "1.0.20"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#000b830535a0b4d6374bc09727e3663fb6af9b89"
 dependencies = [
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
- "alloy-serde 1.0.9",
- "alloy-trie 0.8.1",
+ "alloy-eips 1.0.20",
+ "alloy-primitives 1.2.1",
+ "alloy-serde 1.0.20",
+ "alloy-trie 0.9.0",
  "serde",
+ "serde_with",
 ]
 
 [[package]]
 name = "alloy-hardforks"
-version = "0.2.6"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbff8445282ec080c2673692062bd4930d7a0d6bda257caf138cfc650c503000"
+checksum = "819a3620fe125e0fff365363315ee5e24c23169173b19747dfd6deba33db8990"
 dependencies = [
  "alloy-chains",
  "alloy-eip2124 0.2.0",
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.2.1",
  "auto_impl",
  "dyn-clone",
  "serde",
@@ -395,12 +393,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b26fdd571915bafe857fccba4ee1a4f352965800e46a53e4a5f50187b7776fa"
+checksum = "15516116086325c157c18261d768a20677f0f699348000ed391d4ad0dcb82530"
 dependencies = [
- "alloy-primitives 1.2.0",
- "alloy-sol-type-parser 1.2.0",
+ "alloy-primitives 1.2.1",
+ "alloy-sol-type-parser 1.2.1",
  "serde",
  "serde_json",
 ]
@@ -421,12 +419,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc08b31ebf9273839bd9a01f9333cbb7a3abb4e820c312ade349dd18bdc79581"
+version = "1.0.20"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#000b830535a0b4d6374bc09727e3663fb6af9b89"
 dependencies = [
- "alloy-primitives 1.2.0",
- "alloy-sol-types 1.2.0",
+ "alloy-primitives 1.2.1",
+ "alloy-sol-types 1.2.1",
+ "http 1.3.1",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -435,21 +433,20 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed117b08f0cc190312bf0c38c34cf4f0dabfb4ea8f330071c587cd7160a88cb2"
+version = "1.0.20"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#000b830535a0b4d6374bc09727e3663fb6af9b89"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-consensus-any 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-json-rpc 1.0.9",
- "alloy-network-primitives 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.20",
+ "alloy-consensus-any 1.0.20",
+ "alloy-eips 1.0.20",
+ "alloy-json-rpc 1.0.20",
+ "alloy-network-primitives 1.0.20",
+ "alloy-primitives 1.2.1",
  "alloy-rpc-types-any",
- "alloy-rpc-types-eth 1.0.9",
- "alloy-serde 1.0.9",
+ "alloy-rpc-types-eth 1.0.20",
+ "alloy-serde 1.0.20",
  "alloy-signer",
- "alloy-sol-types 1.2.0",
+ "alloy-sol-types 1.2.1",
  "async-trait",
  "auto_impl",
  "derive_more 2.0.1",
@@ -474,27 +471,26 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7162ff7be8649c0c391f4e248d1273e85c62076703a1f3ec7daf76b283d886d"
+version = "1.0.20"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#000b830535a0b4d6374bc09727e3663fb6af9b89"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
- "alloy-serde 1.0.9",
+ "alloy-consensus 1.0.20",
+ "alloy-eips 1.0.20",
+ "alloy-primitives 1.2.1",
+ "alloy-serde 1.0.20",
  "serde",
 ]
 
 [[package]]
 name = "alloy-node-bindings"
-version = "1.0.9"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eec6d2e7743d2bcb3e7dfc9cb7a7322bc0f808fddd48f4aab5d974260f2ae0cf"
+checksum = "15fdb7f13794430ec98cf9a8bca8d9509ade14d12b260b6d7b7e0d133f6631fc"
 dependencies = [
  "alloy-genesis",
  "alloy-hardforks",
  "alloy-network",
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.2.1",
  "alloy-signer",
  "alloy-signer-local",
  "k256 0.13.4",
@@ -516,7 +512,7 @@ dependencies = [
  "bytes",
  "cfg-if",
  "const-hex",
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
  "hex-literal",
  "itoa",
  "k256 0.13.4",
@@ -540,8 +536,8 @@ dependencies = [
  "const-hex",
  "derive_more 2.0.1",
  "foldhash",
- "hashbrown 0.15.2",
- "indexmap 2.9.0",
+ "hashbrown 0.15.4",
+ "indexmap 2.10.0",
  "itoa",
  "k256 0.13.4",
  "keccak-asm",
@@ -557,9 +553,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a326d47106039f38b811057215a92139f46eef7983a4b77b10930a0ea5685b1e"
+checksum = "6177ed26655d4e84e00b65cb494d4e0b8830e7cae7ef5d63087d445a2600fb55"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -569,16 +565,16 @@ dependencies = [
  "derive_arbitrary",
  "derive_more 2.0.1",
  "foldhash",
- "getrandom 0.3.2",
- "hashbrown 0.15.2",
- "indexmap 2.9.0",
+ "getrandom 0.3.3",
+ "hashbrown 0.15.4",
+ "indexmap 2.10.0",
  "itoa",
  "k256 0.13.4",
  "keccak-asm",
  "paste",
  "proptest",
  "proptest-derive",
- "rand 0.9.0",
+ "rand 0.9.1",
  "ruint",
  "rustc-hash 2.1.1",
  "serde",
@@ -588,22 +584,21 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d84eba1fd8b6fe8b02f2acd5dd7033d0f179e304bd722d11e817db570d1fa6c4"
+version = "1.0.20"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#000b830535a0b4d6374bc09727e3663fb6af9b89"
 dependencies = [
  "alloy-chains",
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-json-rpc 1.0.9",
+ "alloy-consensus 1.0.20",
+ "alloy-eips 1.0.20",
+ "alloy-json-rpc 1.0.20",
  "alloy-network",
- "alloy-network-primitives 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-network-primitives 1.0.20",
+ "alloy-primitives 1.2.1",
  "alloy-pubsub",
  "alloy-rpc-client",
- "alloy-rpc-types-eth 1.0.9",
+ "alloy-rpc-types-eth 1.0.20",
  "alloy-signer",
- "alloy-sol-types 1.2.0",
+ "alloy-sol-types 1.2.1",
  "alloy-transport",
  "alloy-transport-http",
  "alloy-transport-ipc",
@@ -615,10 +610,11 @@ dependencies = [
  "either",
  "futures",
  "futures-utils-wasm",
+ "http 1.3.1",
  "lru 0.13.0",
  "parking_lot",
  "pin-project",
- "reqwest 0.12.15",
+ "reqwest 0.12.22",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -630,12 +626,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8550f7306e0230fc835eb2ff4af0a96362db4b6fc3f25767d161e0ad0ac765bf"
+version = "1.0.20"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#000b830535a0b4d6374bc09727e3663fb6af9b89"
 dependencies = [
- "alloy-json-rpc 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-json-rpc 1.0.20",
+ "alloy-primitives 1.2.1",
  "alloy-transport",
  "bimap",
  "futures",
@@ -651,9 +646,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6c1d995bff8d011f7cd6c81820d51825e6e06d6db73914c1630ecf544d83d6"
+checksum = "5f70d83b765fdc080dbcd4f4db70d8d23fe4761f2f02ebfa9146b833900634b4"
 dependencies = [
  "alloy-rlp-derive",
  "arrayvec",
@@ -662,23 +657,22 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp-derive"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a40e1ef334153322fd878d07e86af7a529bcb86b2439525920a88eba87bcf943"
+checksum = "64b728d511962dda67c1bc7ea7c03736ec275ed2cf4c35d9585298ac9ccf3b73"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "alloy-rpc-client"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "518a699422a3eab800f3dac2130d8f2edba8e4fff267b27a9c7dc6a2b0d313ee"
+version = "1.0.20"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#000b830535a0b4d6374bc09727e3663fb6af9b89"
 dependencies = [
- "alloy-json-rpc 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-json-rpc 1.0.20",
+ "alloy-primitives 1.2.1",
  "alloy-pubsub",
  "alloy-transport",
  "alloy-transport-http",
@@ -687,7 +681,7 @@ dependencies = [
  "async-stream",
  "futures",
  "pin-project",
- "reqwest 0.12.15",
+ "reqwest 0.12.22",
  "serde",
  "serde_json",
  "tokio",
@@ -701,60 +695,55 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c000cab4ec26a4b3e29d144e999e1c539c2fa0abed871bf90311eb3466187ca8"
+version = "1.0.20"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#000b830535a0b4d6374bc09727e3663fb6af9b89"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.2.1",
  "alloy-rpc-types-engine",
- "alloy-rpc-types-eth 1.0.9",
- "alloy-serde 1.0.9",
+ "alloy-rpc-types-eth 1.0.20",
+ "alloy-serde 1.0.20",
  "serde",
 ]
 
 [[package]]
 name = "alloy-rpc-types-admin"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ebdc864f573645c5288370c208912b85b5cacc8025b700c50c2b74d06ab9830"
+version = "1.0.20"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#000b830535a0b4d6374bc09727e3663fb6af9b89"
 dependencies = [
  "alloy-genesis",
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.2.1",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8abecc34549a208b5f91bc7f02df3205c36e2aa6586f1d9375c3382da1066b3b"
+version = "1.0.20"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#000b830535a0b4d6374bc09727e3663fb6af9b89"
 dependencies = [
- "alloy-primitives 1.2.0",
- "alloy-rpc-types-eth 1.0.9",
- "alloy-serde 1.0.9",
+ "alloy-primitives 1.2.1",
+ "alloy-rpc-types-eth 1.0.20",
+ "alloy-serde 1.0.20",
  "serde",
 ]
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "508b2fbe66d952089aa694e53802327798806498cd29ff88c75135770ecaabfc"
+version = "1.0.20"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#000b830535a0b4d6374bc09727e3663fb6af9b89"
 dependencies = [
- "alloy-consensus-any 1.0.9",
- "alloy-rpc-types-eth 1.0.9",
- "alloy-serde 1.0.9",
+ "alloy-consensus-any 1.0.20",
+ "alloy-rpc-types-eth 1.0.20",
+ "alloy-serde 1.0.20",
 ]
 
 [[package]]
 name = "alloy-rpc-types-beacon"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "241aba7808bddc3ad1c6228e296a831f326f89118b1017012090709782a13334"
+version = "1.0.20"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#000b830535a0b4d6374bc09727e3663fb6af9b89"
 dependencies = [
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-eips 1.0.20",
+ "alloy-primitives 1.2.1",
  "alloy-rpc-types-engine",
  "ethereum_ssz 0.9.0",
  "ethereum_ssz_derive 0.9.0",
@@ -767,25 +756,23 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c832f2e851801093928dbb4b7bd83cd22270faf76b2e080646b806a285c8757"
+version = "1.0.20"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#000b830535a0b4d6374bc09727e3663fb6af9b89"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.2.1",
  "serde",
 ]
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab52691970553d84879d777419fa7b6a2e92e9fe8641f9324cc071008c2f656"
+version = "1.0.20"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#000b830535a0b4d6374bc09727e3663fb6af9b89"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.20",
+ "alloy-eips 1.0.20",
+ "alloy-primitives 1.2.1",
  "alloy-rlp",
- "alloy-serde 1.0.9",
+ "alloy-serde 1.0.20",
  "derive_more 2.0.1",
  "ethereum_ssz 0.9.0",
  "ethereum_ssz_derive 0.9.0",
@@ -817,49 +804,47 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcaf7dff0fdd756a714d58014f4f8354a1706ebf9fa2cf73431e0aeec3c9431e"
+version = "1.0.20"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#000b830535a0b4d6374bc09727e3663fb6af9b89"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-consensus-any 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-network-primitives 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.20",
+ "alloy-consensus-any 1.0.20",
+ "alloy-eips 1.0.20",
+ "alloy-network-primitives 1.0.20",
+ "alloy-primitives 1.2.1",
  "alloy-rlp",
- "alloy-serde 1.0.9",
- "alloy-sol-types 1.2.0",
+ "alloy-serde 1.0.20",
+ "alloy-sol-types 1.2.1",
  "arbitrary",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "serde",
  "serde_json",
+ "serde_with",
  "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "alloy-rpc-types-mev"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18bd1c5d7b9f3f1caeeaa1c082aa28ba7ce2d67127b12b2a9b462712c8f6e1c5"
+version = "1.0.20"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#000b830535a0b4d6374bc09727e3663fb6af9b89"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
- "alloy-rpc-types-eth 1.0.9",
- "alloy-serde 1.0.9",
+ "alloy-consensus 1.0.20",
+ "alloy-eips 1.0.20",
+ "alloy-primitives 1.2.1",
+ "alloy-rpc-types-eth 1.0.20",
+ "alloy-serde 1.0.20",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e3507a04e868dd83219ad3cd6a8c58aefccb64d33f426b3934423a206343e84"
+version = "1.0.20"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#000b830535a0b4d6374bc09727e3663fb6af9b89"
 dependencies = [
- "alloy-primitives 1.2.0",
- "alloy-rpc-types-eth 1.0.9",
- "alloy-serde 1.0.9",
+ "alloy-primitives 1.2.1",
+ "alloy-rpc-types-eth 1.0.20",
+ "alloy-serde 1.0.20",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -867,13 +852,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-txpool"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eec36272621c3ac82b47dd77f0508346687730b1c2e3e10d3715705c217c0a05"
+version = "1.0.20"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#000b830535a0b4d6374bc09727e3663fb6af9b89"
 dependencies = [
- "alloy-primitives 1.2.0",
- "alloy-rpc-types-eth 1.0.9",
- "alloy-serde 1.0.9",
+ "alloy-primitives 1.2.1",
+ "alloy-rpc-types-eth 1.0.20",
+ "alloy-serde 1.0.20",
  "serde",
 ]
 
@@ -890,11 +874,10 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "730e8f2edf2fc224cabd1c25d090e1655fa6137b2e409f92e5eec735903f1507"
+version = "1.0.20"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#000b830535a0b4d6374bc09727e3663fb6af9b89"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.2.1",
  "arbitrary",
  "serde",
  "serde_json",
@@ -902,11 +885,10 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b0d2428445ec13edc711909e023d7779618504c4800be055a5b940025dbafe3"
+version = "1.0.20"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#000b830535a0b4d6374bc09727e3663fb6af9b89"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.2.1",
  "async-trait",
  "auto_impl",
  "either",
@@ -917,13 +899,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14fe6fedb7fe6e0dfae47fe020684f1d8e063274ef14bca387ddb7a6efa8ec1"
+version = "1.0.20"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#000b830535a0b4d6374bc09727e3663fb6af9b89"
 dependencies = [
- "alloy-consensus 1.0.9",
+ "alloy-consensus 1.0.20",
  "alloy-network",
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.2.1",
  "alloy-signer",
  "async-trait",
  "k256 0.13.4",
@@ -942,21 +923,21 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "alloy-sol-macro"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4be1ce1274ddd7fdfac86e5ece1b225e9bba1f2327e20fbb30ee6b9cc1423fe"
+checksum = "a14f21d053aea4c6630687c2f4ad614bed4c81e14737a9b904798b24f30ea849"
 dependencies = [
- "alloy-sol-macro-expander 1.2.0",
- "alloy-sol-macro-input 1.2.0",
+ "alloy-sol-macro-expander 1.2.1",
+ "alloy-sol-macro-input 1.2.1",
  "proc-macro-error2",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -968,30 +949,30 @@ dependencies = [
  "alloy-sol-macro-input 0.8.25",
  "const-hex",
  "heck 0.5.0",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "proc-macro-error2",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
  "syn-solidity 0.8.25",
  "tiny-keccak",
 ]
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01e92f3708ea4e0d9139001c86c051c538af0146944a2a9c7181753bd944bf57"
+checksum = "34d99282e7c9ef14eb62727981a985a01869e586d1dec729d3bb33679094c100"
 dependencies = [
- "alloy-sol-macro-input 1.2.0",
+ "alloy-sol-macro-input 1.2.1",
  "const-hex",
  "heck 0.5.0",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "proc-macro-error2",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
- "syn-solidity 1.2.0",
+ "syn 2.0.104",
+ "syn-solidity 1.2.1",
  "tiny-keccak",
 ]
 
@@ -1007,15 +988,15 @@ dependencies = [
  "macro-string",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
  "syn-solidity 0.8.25",
 ]
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afe1bd348a41f8c9b4b54dfb314886786d6201235b0b3f47198b9d910c86bb2"
+checksum = "eda029f955b78e493360ee1d7bd11e1ab9f2a220a5715449babc79d6d0a01105"
 dependencies = [
  "const-hex",
  "dunce",
@@ -1023,8 +1004,8 @@ dependencies = [
  "macro-string",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
- "syn-solidity 1.2.0",
+ "syn 2.0.104",
+ "syn-solidity 1.2.1",
 ]
 
 [[package]]
@@ -1039,9 +1020,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6195df2acd42df92a380a8db6205a5c7b41282d0ce3f4c665ecf7911ac292f1"
+checksum = "10db1bd7baa35bc8d4a1b07efbf734e73e5ba09f2580fb8cee3483a36087ceb2"
 dependencies = [
  "serde",
  "winnow",
@@ -1062,24 +1043,23 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6185e98a79cf19010722f48a74b5a65d153631d2f038cabd250f4b9e9813b8ad"
+checksum = "58377025a47d8b8426b3e4846a251f2c1991033b27f517aade368146f6ab1dfe"
 dependencies = [
- "alloy-json-abi 1.2.0",
- "alloy-primitives 1.2.0",
- "alloy-sol-macro 1.2.0",
+ "alloy-json-abi 1.2.1",
+ "alloy-primitives 1.2.1",
+ "alloy-sol-macro 1.2.1",
  "serde",
 ]
 
 [[package]]
 name = "alloy-transport"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a712bdfeff42401a7dd9518f72f617574c36226a9b5414537fedc34350b73bf9"
+version = "1.0.20"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#000b830535a0b4d6374bc09727e3663fb6af9b89"
 dependencies = [
- "alloy-json-rpc 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-json-rpc 1.0.20",
+ "alloy-primitives 1.2.1",
  "base64 0.22.1",
  "derive_more 2.0.1",
  "futures",
@@ -1097,13 +1077,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ea5a76d7f2572174a382aedf36875bedf60bcc41116c9f031cf08040703a2dc"
+version = "1.0.20"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#000b830535a0b4d6374bc09727e3663fb6af9b89"
 dependencies = [
- "alloy-json-rpc 1.0.9",
+ "alloy-json-rpc 1.0.20",
  "alloy-transport",
- "reqwest 0.12.15",
+ "reqwest 0.12.22",
  "serde_json",
  "tower 0.5.2",
  "tracing",
@@ -1112,11 +1091,10 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "606af17a7e064d219746f6d2625676122c79d78bf73dfe746d6db9ecd7dbcb85"
+version = "1.0.20"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#000b830535a0b4d6374bc09727e3663fb6af9b89"
 dependencies = [
- "alloy-json-rpc 1.0.9",
+ "alloy-json-rpc 1.0.20",
  "alloy-pubsub",
  "alloy-transport",
  "bytes",
@@ -1132,15 +1110,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c6f9b37cd8d44aab959613966cc9d4d7a9b429c575cec43b3e5b46ea109a79"
+version = "1.0.20"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#000b830535a0b4d6374bc09727e3663fb6af9b89"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
  "futures",
  "http 1.3.1",
- "rustls 0.23.26",
+ "rustls 0.23.29",
  "serde_json",
  "tokio",
  "tokio-tungstenite 0.26.2",
@@ -1158,7 +1135,7 @@ dependencies = [
  "alloy-rlp",
  "arrayvec",
  "derive_more 1.0.0",
- "nybbles",
+ "nybbles 0.3.4",
  "serde",
  "smallvec",
  "tracing",
@@ -1170,18 +1147,45 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "983d99aa81f586cef9dae38443245e585840fcf0fc58b09aee0b1f27aed1d500"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.2.1",
+ "alloy-rlp",
+ "arrayvec",
+ "derive_more 2.0.1",
+ "nybbles 0.3.4",
+ "smallvec",
+ "tracing",
+]
+
+[[package]]
+name = "alloy-trie"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bada1fc392a33665de0dc50d401a3701b62583c655e3522a323490a5da016962"
+dependencies = [
+ "alloy-primitives 1.2.1",
  "alloy-rlp",
  "arbitrary",
  "arrayvec",
  "derive_arbitrary",
  "derive_more 2.0.1",
- "nybbles",
+ "nybbles 0.4.1",
  "proptest",
  "proptest-derive",
  "serde",
  "smallvec",
  "tracing",
+]
+
+[[package]]
+name = "alloy-tx-macros"
+version = "1.0.20"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#000b830535a0b4d6374bc09727e3663fb6af9b89"
+dependencies = [
+ "alloy-primitives 1.2.1",
+ "darling 0.20.11",
+ "proc-macro2 1.0.95",
+ "quote 1.0.40",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1207,9 +1211,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.18"
+version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -1222,36 +1226,36 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
 dependencies = [
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.7"
+version = "3.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
 dependencies = [
  "anstyle",
- "once_cell",
+ "once_cell_polyfill",
  "windows-sys 0.59.0",
 ]
 
@@ -1272,7 +1276,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1286,9 +1290,9 @@ dependencies = [
 
 [[package]]
 name = "argminmax"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52424b59d69d69d5056d508b260553afd91c57e21849579cd1f50ee8b8b88eaa"
+checksum = "70f13d10a41ac8d2ec79ee34178d61e6f47a29c2edfe7ef1721c7383b0359e65"
 dependencies = [
  "num-traits",
 ]
@@ -1330,7 +1334,7 @@ dependencies = [
  "ark-std 0.5.0",
  "educe",
  "fnv",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.4",
  "itertools 0.13.0",
  "num-bigint",
  "num-integer",
@@ -1423,7 +1427,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
 dependencies = [
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1461,7 +1465,7 @@ dependencies = [
  "num-traits",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1476,7 +1480,7 @@ dependencies = [
  "ark-std 0.5.0",
  "educe",
  "fnv",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.4",
 ]
 
 [[package]]
@@ -1550,7 +1554,7 @@ checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1631,7 +1635,7 @@ dependencies = [
  "fallible-streaming-iterator",
  "foreign_vec",
  "futures",
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "hash_hasher",
  "lexical-core",
  "lz4",
@@ -1681,11 +1685,11 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.22"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59a194f9d963d8099596278594b3107448656ba73831c9d8c783e613ce86da64"
+checksum = "ddb939d66e4ae03cee6091612804ba446b12878410cfa17f785f4dd67d4014e8"
 dependencies = [
- "brotli 7.0.0",
+ "brotli 8.0.1",
  "flate2",
  "futures-core",
  "memchr",
@@ -1702,17 +1706,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
 dependencies = [
  "event-listener",
-]
-
-[[package]]
-name = "async-recursion"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
-dependencies = [
- "proc-macro2 1.0.95",
- "quote 1.0.40",
- "syn 2.0.100",
 ]
 
 [[package]]
@@ -1748,7 +1741,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1759,7 +1752,7 @@ checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1817,7 +1810,7 @@ checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1826,20 +1819,26 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dde43e75fd43e8a1bf86103336bc699aa8d17ad1be60c76c0bdfd4828e19b78"
 dependencies = [
- "autocfg 1.4.0",
+ "autocfg 1.5.0",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "az"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
 
 [[package]]
 name = "backon"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd0b50b1b78dbadd44ab18b3c794e496f3a139abb9fbc27d9c94c4eebbb96496"
+checksum = "302eaff5357a264a2c42f127ecb8bac761cf99749fc3dc95677e2743991f99e7"
 dependencies = [
  "fastrand 2.3.0",
  "tokio",
@@ -1847,9 +1846,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.74"
+version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -1898,16 +1897,16 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.7.3"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
+checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
 name = "beacon-api-client"
 version = "0.1.0"
-source = "git+https://github.com/ralexstokes/ethereum-consensus/?rev=ade5ce6c4a19107c1059e5338d8f18855bd2d931#ade5ce6c4a19107c1059e5338d8f18855bd2d931"
+source = "git+https://github.com/ralexstokes/ethereum-consensus/?rev=5031d31e318dd861cf3373702c5d92f085d926e4#5031d31e318dd861cf3373702c5d92f085d926e4"
 dependencies = [
- "clap 4.5.36",
+ "clap 4.5.41",
  "ethereum-consensus",
  "http 0.2.12",
  "itertools 0.10.5",
@@ -1966,7 +1965,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite 0.19.0",
  "tokio-util",
- "toml 0.8.20",
+ "toml 0.8.23",
  "tracing",
  "tracing-subscriber 0.3.19",
 ]
@@ -1988,7 +1987,7 @@ version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a22f228ab7a1b23027ccc6c350b72868017af7ea8356fbdf19f8d991c690013"
 dependencies = [
- "autocfg 1.4.0",
+ "autocfg 1.5.0",
  "libm",
  "num-bigint",
  "num-integer",
@@ -2016,7 +2015,7 @@ version = "0.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -2025,7 +2024,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2082,9 +2081,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 dependencies = [
  "serde",
 ]
@@ -2104,9 +2103,9 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389a099b34312839e16420d499a9cad9650541715937ffbdd40d36f49e77eeb3"
+checksum = "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -2144,9 +2143,9 @@ dependencies = [
 
 [[package]]
 name = "blst"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c79a94619fade3c0b887670333513a67ac28a6a7e653eb260bf0d4103db38d"
+checksum = "4fd49896f12ac9b6dcd7a5998466b9b58263a695a3dd1ecc1aaca2e12a90b080"
 dependencies = [
  "cc",
  "glob",
@@ -2160,11 +2159,11 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c340fe0f0b267787095cbe35240c6786ff19da63ec7b69367ba338eace8169b"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "boa_interner",
  "boa_macros",
  "boa_string",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "num-bigint",
  "rustc-hash 2.1.1",
 ]
@@ -2176,7 +2175,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f620c3f06f51e65c0504ddf04978be1b814ac6586f0b45f6019801ab5efd37f9"
 dependencies = [
  "arrayvec",
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "boa_ast",
  "boa_gc",
  "boa_interner",
@@ -2188,9 +2187,9 @@ dependencies = [
  "cfg-if",
  "dashmap 6.1.0",
  "fast-float2",
- "hashbrown 0.15.2",
- "icu_normalizer",
- "indexmap 2.9.0",
+ "hashbrown 0.15.4",
+ "icu_normalizer 1.5.0",
+ "indexmap 2.10.0",
  "intrusive-collections",
  "itertools 0.13.0",
  "num-bigint",
@@ -2223,7 +2222,7 @@ dependencies = [
  "boa_macros",
  "boa_profiler",
  "boa_string",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.4",
  "thin-vec",
 ]
 
@@ -2235,8 +2234,8 @@ checksum = "42407a3b724cfaecde8f7d4af566df4b56af32a2f11f0956f5570bb974e7f749"
 dependencies = [
  "boa_gc",
  "boa_macros",
- "hashbrown 0.15.2",
- "indexmap 2.9.0",
+ "hashbrown 0.15.4",
+ "indexmap 2.10.0",
  "once_cell",
  "phf 0.11.3",
  "rustc-hash 2.1.1",
@@ -2251,8 +2250,8 @@ checksum = "9fd3f870829131332587f607a7ff909f1af5fc523fd1b192db55fbbdf52e8d3c"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
- "synstructure 0.13.1",
+ "syn 2.0.104",
+ "synstructure 0.13.2",
 ]
 
 [[package]]
@@ -2261,13 +2260,13 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cc142dac798cdc6e2dbccfddeb50f36d2523bb977a976e19bdb3ae19b740804"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "boa_ast",
  "boa_interner",
  "boa_macros",
  "boa_profiler",
  "fast-float2",
- "icu_properties",
+ "icu_properties 1.5.1",
  "num-bigint",
  "num-traits",
  "regress",
@@ -2315,13 +2314,13 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "7.0.0"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc97b8f16f944bba54f0433f07e30be199b6dc2bd25937444bbad560bcea29bd"
+checksum = "9991eea70ea4f293524138648e41ee89b0b2b12ddef3b255effa43c8056e0e0d"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
- "brotli-decompressor 4.0.2",
+ "brotli-decompressor 5.0.0",
 ]
 
 [[package]]
@@ -2336,9 +2335,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "4.0.2"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74fa05ad7d803d413eb8380983b092cbbaf9a85f151b871360e7b00cd7060b37"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -2356,7 +2355,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
 dependencies = [
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "tinyvec",
 ]
 
@@ -2383,9 +2382,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "byte-slice-cast"
@@ -2395,15 +2394,15 @@ checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
 name = "bytecount"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytemuck"
-version = "1.22.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
+checksum = "5c76a5792e44e4abe34d3abf15636779261d45a7450612059293d1d2cfc63422"
 dependencies = [
  "bytemuck_derive",
 ]
@@ -2416,7 +2415,7 @@ checksum = "7ecc273b49b3205b83d648f0690daa588925572cc5063745bfe547fe7ec8e1a1"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2472,9 +2471,9 @@ dependencies = [
 
 [[package]]
 name = "camino"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
+checksum = "0da45bc31171d8d6960122e222a67740df867c1dd53b4d51caa297084c185cab"
 dependencies = [
  "serde",
 ]
@@ -2543,9 +2542,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "castaway"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0abae9be0aaf9ea96a3b1b8b1b55c602ca751eba1b1500220cea4ecbafe7c0d5"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
 dependencies = [
  "rustversion",
 ]
@@ -2578,9 +2577,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "cfg_aliases"
@@ -2590,9 +2589,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.40"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -2670,23 +2669,23 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.36"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2df961d8c8a0d08aa9945718ccf584145eee3f3aa06cddbeac12933781102e04"
+checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
 dependencies = [
  "clap_builder",
- "clap_derive 4.5.32",
+ "clap_derive 4.5.41",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.36"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "132dbda40fb6753878316a489d5a1242a8ef2f0d9e47ba01c951ea8aa7d013a5"
+checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
 dependencies = [
  "anstream",
  "anstyle",
- "clap_lex 0.7.4",
+ "clap_lex 0.7.5",
  "strsim 0.11.1",
 ]
 
@@ -2705,14 +2704,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.32"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
+checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2726,9 +2725,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "cloudabi"
@@ -2757,10 +2756,10 @@ dependencies = [
  "bs58 0.5.1",
  "coins-core",
  "digest 0.10.7",
- "hmac 0.12.1",
+ "hmac",
  "k256 0.13.4",
  "serde",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
 ]
 
@@ -2772,11 +2771,11 @@ checksum = "3db8fba409ce3dc04f7d804074039eb68b960b0829161f8e06c95fea3f122528"
 dependencies = [
  "bitvec",
  "coins-bip32",
- "hmac 0.12.1",
+ "hmac",
  "once_cell",
  "pbkdf2 0.12.2",
  "rand 0.8.5",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
 ]
 
@@ -2795,16 +2794,16 @@ dependencies = [
  "ripemd",
  "serde",
  "serde_derive",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "sha3",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "colorchoice"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "combine"
@@ -2874,9 +2873,9 @@ dependencies = [
 
 [[package]]
 name = "const-hex"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b0485bab839b018a8f1723fc5391819fea5f8f0f32288ef8a735fd096b6160c"
+checksum = "83e22e0ed40b96a48d3db274f72fd365bd78f67af39b6bbd47e8a15e1c6207ff"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2950,9 +2949,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2984,9 +2983,9 @@ dependencies = [
 
 [[package]]
 name = "crc"
-version = "3.2.1"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
+checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
 dependencies = [
  "crc-catalog",
 ]
@@ -2999,9 +2998,9 @@ checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crc32fast"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
@@ -3041,7 +3040,7 @@ dependencies = [
  "anes",
  "cast",
  "ciborium",
- "clap 4.5.36",
+ "clap 4.5.41",
  "criterion-plot",
  "futures",
  "is-terminal",
@@ -3138,7 +3137,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "crossterm_winapi",
  "mio",
  "parking_lot",
@@ -3159,9 +3158,9 @@ dependencies = [
 
 [[package]]
 name = "crunchy"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
@@ -3199,16 +3198,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-mac"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
-dependencies = [
- "generic-array",
- "subtle",
-]
-
-[[package]]
 name = "cssparser"
 version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3228,7 +3217,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3259,7 +3248,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3273,9 +3262,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.3"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+checksum = "373b7c5dbd637569a2cca66e8d66b8c446a1e7bf064ea321d265d7b3dfe7c97e"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -3295,7 +3284,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3343,7 +3332,7 @@ dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
  "strsim 0.11.1",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3365,7 +3354,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3419,7 +3408,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3451,9 +3440,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
  "pem-rfc7468",
@@ -3483,13 +3472,13 @@ dependencies = [
 
 [[package]]
 name = "derive-where"
-version = "1.2.7"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62d671cc41a825ebabc75757b62d3d168c577f9149b2d49ece1dad1f72119d25"
+checksum = "510c292c8cf384b1a340b816a9a6cf2599eb8f566a44949024af88418000c50b"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3500,7 +3489,7 @@ checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3521,7 +3510,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3531,20 +3520,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "derive_more"
-version = "0.99.19"
+version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da29a38df43d6f156149c9b43ded5e018ddff2a855cf2cfd62e8cd7d079c69f"
+checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
 dependencies = [
  "convert_case 0.4.0",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
  "rustc_version 0.4.1",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3573,7 +3562,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3585,7 +3574,7 @@ dependencies = [
  "convert_case 0.7.1",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
  "unicode-xid 0.2.6",
 ]
 
@@ -3665,7 +3654,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3720,7 +3709,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3786,7 +3775,7 @@ version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der 0.7.9",
+ "der 0.7.10",
  "digest 0.10.7",
  "elliptic-curve 0.13.8",
  "rfc6979 0.4.0",
@@ -3807,15 +3796,15 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
  "rand_core 0.6.4",
  "serde",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -3829,7 +3818,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3962,7 +3951,7 @@ dependencies = [
  "k256 0.13.4",
  "log",
  "rand 0.8.5",
- "secp256k1",
+ "secp256k1 0.30.0",
  "serde",
  "sha3",
  "zeroize",
@@ -3977,7 +3966,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3997,7 +3986,7 @@ checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4009,7 +3998,7 @@ dependencies = [
  "once_cell",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4020,12 +4009,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.11"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4058,13 +4047,13 @@ dependencies = [
  "ctr",
  "digest 0.10.7",
  "hex",
- "hmac 0.12.1",
+ "hmac",
  "pbkdf2 0.11.0",
  "rand 0.8.5",
  "scrypt",
  "serde",
  "serde_json",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "sha3",
  "thiserror 1.0.69",
  "uuid 0.8.2",
@@ -4074,7 +4063,7 @@ dependencies = [
 name = "eth-sparse-mpt"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.2.1",
  "alloy-rlp",
  "alloy-trie 0.8.1",
  "arrayvec",
@@ -4084,6 +4073,7 @@ dependencies = [
  "eyre",
  "flate2",
  "hash-db",
+ "nybbles 0.3.4",
  "parking_lot",
  "proptest",
  "rand 0.8.5",
@@ -4139,7 +4129,7 @@ dependencies = [
 [[package]]
 name = "ethereum-consensus"
 version = "0.1.1"
-source = "git+https://github.com/ralexstokes/ethereum-consensus/?rev=ade5ce6c4a19107c1059e5338d8f18855bd2d931#ade5ce6c4a19107c1059e5338d8f18855bd2d931"
+source = "git+https://github.com/ralexstokes/ethereum-consensus/?rev=5031d31e318dd861cf3373702c5d92f085d926e4#5031d31e318dd861cf3373702c5d92f085d926e4"
 dependencies = [
  "blst",
  "bs58 0.4.0",
@@ -4153,7 +4143,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "ssz_rs",
  "thiserror 1.0.69",
  "tokio",
@@ -4184,7 +4174,7 @@ checksum = "c853bd72c9e5787f8aafc3df2907c2ed03cff3150c3acd94e2e53a98ab70a8ab"
 dependencies = [
  "cpufeatures",
  "ring 0.17.14",
- "sha2 0.10.8",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -4196,7 +4186,7 @@ dependencies = [
  "cpufeatures",
  "lazy_static",
  "ring 0.16.20",
- "sha2 0.10.8",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -4218,7 +4208,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dc1355dbb41fbbd34ec28d4fb2a57d9a70c67ac3c19f6a5ca4d4a176b9e997a"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.2.1",
  "hex",
  "serde",
  "serde_derive",
@@ -4242,7 +4232,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ca8ba45b63c389c6e115b095ca16381534fdcc03cf58176a3f8554db2dbe19b"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.2.1",
  "ethereum_serde_utils 0.8.0",
  "itertools 0.13.0",
  "serde",
@@ -4272,7 +4262,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4341,8 +4331,8 @@ dependencies = [
  "reqwest 0.11.27",
  "serde",
  "serde_json",
- "syn 2.0.100",
- "toml 0.8.20",
+ "syn 2.0.104",
+ "toml 0.8.23",
  "walkdir",
 ]
 
@@ -4359,7 +4349,7 @@ dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
  "serde_json",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4385,7 +4375,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum 0.26.3",
- "syn 2.0.100",
+ "syn 2.0.104",
  "tempfile",
  "thiserror 1.0.69",
  "tiny-keccak",
@@ -4486,7 +4476,7 @@ dependencies = [
  "eth-keystore",
  "ethers-core",
  "rand 0.8.5",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "tracing",
 ]
@@ -4525,9 +4515,9 @@ dependencies = [
 
 [[package]]
 name = "ethnum"
-version = "1.5.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0939f82868b77ef93ce3c3c3daf2b3c526b456741da5a1a4559e590965b6026b"
+checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
 
 [[package]]
 name = "event-listener"
@@ -4641,9 +4631,9 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.9"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "filetime"
@@ -4677,9 +4667,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
+checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -4911,7 +4901,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5006,15 +4996,16 @@ dependencies = [
 
 [[package]]
 name = "generator"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6bd114ceda131d3b1d665eba35788690ad37f5916457286b32ab6fd3c438dd"
+checksum = "d18470a76cb7f8ff746cf1f7470914f900252ec36bbc40b569d74b1258446827"
 dependencies = [
+ "cc",
  "cfg-if",
  "libc",
  "log",
  "rustversion",
- "windows 0.58.0",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -5031,11 +5022,11 @@ dependencies = [
 
 [[package]]
 name = "getopts"
-version = "0.2.21"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
+checksum = "cba6ae63eb948698e300f645f87c70f76630d505f23b8907cf1e193ee85048c1"
 dependencies = [
- "unicode-width 0.1.14",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -5051,22 +5042,22 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -5094,11 +5085,11 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "git2"
-version = "0.20.1"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5220b8ba44c68a9a7f7a7659e864dd73692e417ef0211bea133c7b74e031eeb9"
+checksum = "2deb07a133b1520dc1a5690e9bd08950108873d7ed5de38dcc74d3b5ebffa110"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "libc",
  "libgit2-sys",
  "log",
@@ -5179,6 +5170,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gmp-mpfr-sys"
+version = "1.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66d61197a68f6323b9afa616cf83d55d69191e1bf364d4eb7d35ae18defe776"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "governor"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5222,9 +5223,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
 dependencies = [
  "bytes",
  "fnv",
@@ -5232,7 +5233,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -5241,9 +5242,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.9"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75249d144030531f8dee69fe9cea04d3edf809a017ae445e2abdff6629e86633"
+checksum = "17da50a276f1e01e0ba6c029e47b7100754904ee8a278f886546e98575380785"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -5251,7 +5252,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.3.1",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -5276,9 +5277,9 @@ checksum = "d23bd4e7b5eda0d0f3a307e8b381fdc8ba9000f26fbe912250c0a4cc3956364a"
 
 [[package]]
 name = "hash_hasher"
-version = "2.0.3"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74721d007512d0cb3338cd20f0654ac913920061a4c4d0d8708edb3f2a698c0c"
+checksum = "1b4b9ebce26001bad2e6366295f64e381c1e9c479109202149b9e15e154973e9"
 
 [[package]]
 name = "hashbrown"
@@ -5308,9 +5309,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -5405,15 +5406,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.9"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
-
-[[package]]
-name = "hermit-abi"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbd780fe5cc30f81464441920d82ac8740e2e46b29a6fad543ddd075229ce37e"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -5441,14 +5436,12 @@ checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hickory-proto"
-version = "0.25.1"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d844af74f7b799e41c78221be863bade11c430d46042c3b49ca8ae0c6d27287"
+checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
 dependencies = [
- "async-recursion",
  "async-trait",
  "cfg-if",
- "critical-section",
  "data-encoding",
  "enum-as-inner",
  "futures-channel",
@@ -5457,7 +5450,7 @@ dependencies = [
  "idna",
  "ipnet",
  "once_cell",
- "rand 0.9.0",
+ "rand 0.9.1",
  "ring 0.17.14",
  "serde",
  "thiserror 2.0.12",
@@ -5469,9 +5462,9 @@ dependencies = [
 
 [[package]]
 name = "hickory-resolver"
-version = "0.25.1"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a128410b38d6f931fcc6ca5c107a3b02cabd6c05967841269a4ad65d23c44331"
+checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -5480,7 +5473,7 @@ dependencies = [
  "moka",
  "once_cell",
  "parking_lot",
- "rand 0.9.0",
+ "rand 0.9.1",
  "resolv-conf",
  "serde",
  "smallvec",
@@ -5495,17 +5488,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac 0.12.1",
-]
-
-[[package]]
-name = "hmac"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
-dependencies = [
- "crypto-mac",
- "digest 0.9.0",
+ "hmac",
 ]
 
 [[package]]
@@ -5518,34 +5501,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "hmac-drbg"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17ea0a1394df5b6574da6e0c1ade9e78868c9fb0a4e5ef4428e32da4676b85b1"
-dependencies = [
- "digest 0.9.0",
- "generic-array",
- "hmac 0.8.1",
-]
-
-[[package]]
 name = "home"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "hostname"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56f203cd1c76362b69e3863fd987520ac36cf70a8c92627449b2f64a8cf7d65"
-dependencies = [
- "cfg-if",
- "libc",
- "windows-link",
 ]
 
 [[package]]
@@ -5688,7 +5649,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.3.26",
+ "h2 0.3.27",
  "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
@@ -5711,7 +5672,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.9",
+ "h2 0.4.11",
  "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
@@ -5741,22 +5702,21 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.5"
+version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "futures-util",
  "http 1.3.1",
  "hyper 1.6.0",
  "hyper-util",
  "log",
- "rustls 0.23.26",
+ "rustls 0.23.29",
  "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.2",
  "tower-service",
- "webpki-roots 0.26.8",
+ "webpki-roots 1.0.1",
 ]
 
 [[package]]
@@ -5790,22 +5750,28 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.11"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2"
+checksum = "7f66d5bd4c6f02bf0542fad85d626775bab9258cf795a4256dcaf3161114d1df"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
+ "futures-core",
  "futures-util",
  "http 1.3.1",
  "http-body 1.0.1",
  "hyper 1.6.0",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration 0.6.1",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -5820,7 +5786,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.0",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -5839,9 +5805,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
 dependencies = [
  "displaydoc",
- "yoke",
+ "yoke 0.7.5",
  "zerofrom",
- "zerovec",
+ "zerovec 0.10.4",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke 0.8.0",
+ "zerofrom",
+ "zerovec 0.11.2",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
+dependencies = [
+ "displaydoc",
+ "litemap 0.8.0",
+ "tinystr 0.8.1",
+ "writeable 0.6.1",
+ "zerovec 0.11.2",
 ]
 
 [[package]]
@@ -5851,10 +5843,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
 dependencies = [
  "displaydoc",
- "litemap",
- "tinystr",
- "writeable",
- "zerovec",
+ "litemap 0.7.5",
+ "tinystr 0.7.6",
+ "writeable 0.5.5",
+ "zerovec 0.10.4",
 ]
 
 [[package]]
@@ -5866,9 +5858,9 @@ dependencies = [
  "displaydoc",
  "icu_locid",
  "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
+ "icu_provider 1.5.0",
+ "tinystr 0.7.6",
+ "zerovec 0.10.4",
 ]
 
 [[package]]
@@ -5884,15 +5876,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
 dependencies = [
  "displaydoc",
- "icu_collections",
- "icu_normalizer_data",
- "icu_properties",
- "icu_provider",
+ "icu_collections 1.5.0",
+ "icu_normalizer_data 1.5.1",
+ "icu_properties 1.5.1",
+ "icu_provider 1.5.0",
  "smallvec",
  "utf16_iter",
  "utf8_iter",
  "write16",
- "zerovec",
+ "zerovec 0.10.4",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
+dependencies = [
+ "displaydoc",
+ "icu_collections 2.0.0",
+ "icu_normalizer_data 2.0.0",
+ "icu_properties 2.0.1",
+ "icu_provider 2.0.0",
+ "smallvec",
+ "zerovec 0.11.2",
 ]
 
 [[package]]
@@ -5902,18 +5909,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5e8338228bdc8ab83303f16b797e177953730f601a96c25d10cb3ab0daa0cb7"
 
 [[package]]
+name = "icu_normalizer_data"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+
+[[package]]
 name = "icu_properties"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
 dependencies = [
  "displaydoc",
- "icu_collections",
+ "icu_collections 1.5.0",
  "icu_locid_transform",
- "icu_properties_data",
- "icu_provider",
- "tinystr",
- "zerovec",
+ "icu_properties_data 1.5.1",
+ "icu_provider 1.5.0",
+ "tinystr 0.7.6",
+ "zerovec 0.10.4",
+]
+
+[[package]]
+name = "icu_properties"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
+dependencies = [
+ "displaydoc",
+ "icu_collections 2.0.0",
+ "icu_locale_core",
+ "icu_properties_data 2.0.1",
+ "icu_provider 2.0.0",
+ "potential_utf",
+ "zerotrie",
+ "zerovec 0.11.2",
 ]
 
 [[package]]
@@ -5921,6 +5950,12 @@ name = "icu_properties_data"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85fb8799753b75aee8d2a21d7c14d9f38921b54b3dbda10f5a3c7a7b82dba5e2"
+
+[[package]]
+name = "icu_properties_data"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
 
 [[package]]
 name = "icu_provider"
@@ -5932,11 +5967,28 @@ dependencies = [
  "icu_locid",
  "icu_provider_macros",
  "stable_deref_trait",
- "tinystr",
- "writeable",
- "yoke",
+ "tinystr 0.7.6",
+ "writeable 0.5.5",
+ "yoke 0.7.5",
  "zerofrom",
- "zerovec",
+ "zerovec 0.10.4",
+]
+
+[[package]]
+name = "icu_provider"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "stable_deref_trait",
+ "tinystr 0.8.1",
+ "writeable 0.6.1",
+ "yoke 0.8.0",
+ "zerofrom",
+ "zerotrie",
+ "zerovec 0.11.2",
 ]
 
 [[package]]
@@ -5947,7 +5999,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5969,12 +6021,12 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
- "icu_normalizer",
- "icu_properties",
+ "icu_normalizer 2.0.0",
+ "icu_properties 2.0.1",
 ]
 
 [[package]]
@@ -6022,7 +6074,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -6056,20 +6108,20 @@ version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
- "autocfg 1.4.0",
+ "autocfg 1.5.0",
  "hashbrown 0.12.3",
  "serde",
 ]
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "arbitrary",
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.4",
  "serde",
 ]
 
@@ -6104,7 +6156,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "inotify-sys",
  "libc",
 ]
@@ -6138,7 +6190,7 @@ dependencies = [
  "indoc",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -6190,6 +6242,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-uring"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "ipconfig"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6223,7 +6286,7 @@ version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
- "hermit-abi 0.5.0",
+ "hermit-abi 0.5.2",
  "libc",
  "windows-sys 0.59.0",
 ]
@@ -6304,7 +6367,7 @@ version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
 dependencies = [
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
  "libc",
 ]
 
@@ -6390,7 +6453,7 @@ dependencies = [
  "http 1.3.1",
  "jsonrpsee-core 0.25.1",
  "pin-project",
- "rustls 0.23.26",
+ "rustls 0.23.29",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "soketto 0.8.1",
@@ -6444,7 +6507,7 @@ dependencies = [
  "jsonrpsee-types 0.25.1",
  "parking_lot",
  "pin-project",
- "rand 0.9.0",
+ "rand 0.9.1",
  "rustc-hash 2.1.1",
  "serde",
  "serde_json",
@@ -6485,11 +6548,11 @@ dependencies = [
  "base64 0.22.1",
  "http-body 1.0.1",
  "hyper 1.6.0",
- "hyper-rustls 0.27.5",
+ "hyper-rustls 0.27.7",
  "hyper-util",
  "jsonrpsee-core 0.25.1",
  "jsonrpsee-types 0.25.1",
- "rustls 0.23.26",
+ "rustls 0.23.29",
  "rustls-platform-verifier",
  "serde",
  "serde_json",
@@ -6522,7 +6585,7 @@ dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -6689,7 +6752,7 @@ dependencies = [
  "cfg-if",
  "ecdsa 0.14.8",
  "elliptic-curve 0.12.3",
- "sha2 0.10.8",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -6703,7 +6766,7 @@ dependencies = [
  "elliptic-curve 0.13.8",
  "once_cell",
  "serdect",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "signature 2.2.0",
 ]
 
@@ -6728,9 +6791,9 @@ dependencies = [
 
 [[package]]
 name = "kqueue"
-version = "1.0.8"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7447f1ca1b7b563588a205fe93dea8df60fd981423a768bc1c0ded35ed147d0c"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
 dependencies = [
  "kqueue-sys",
  "libc",
@@ -6860,15 +6923,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.18.1+1.9.0"
+version = "0.18.2+1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1dcb20f84ffcdd825c7a311ae347cce604a6f084a767dec4a4929829645290e"
+checksum = "1c42fe03df2bd3c53a3a9c7317ad91d80c81cd1fb0caec8d7cc4cd2bfa10c222"
 dependencies = [
  "cc",
  "libc",
@@ -6878,35 +6941,35 @@ dependencies = [
 
 [[package]]
 name = "libloading"
-version = "0.8.6"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
+checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.53.2",
 ]
 
 [[package]]
 name = "libm"
-version = "0.2.11"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libp2p-identity"
-version = "0.2.10"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "257b5621d159b32282eac446bed6670c39c7dc68a200a992d8f056afa0066f6d"
+checksum = "3104e13b51e4711ff5738caa1fb54467c8604c2e94d607e27745bcf709068774"
 dependencies = [
  "asn1_der",
  "bs58 0.5.1",
  "ed25519-dalek",
  "hkdf",
- "libsecp256k1",
+ "k256 0.13.4",
  "multihash 0.19.3",
  "quick-protobuf",
- "sha2 0.10.8",
- "thiserror 1.0.69",
+ "sha2 0.10.9",
+ "thiserror 2.0.12",
  "tracing",
  "zeroize",
 ]
@@ -6924,11 +6987,11 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+checksum = "1580801010e535496706ba011c15f8532df6b42297d2e471fec38ceadd8c0638"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "libc",
  "redox_syscall",
 ]
@@ -6942,14 +7005,12 @@ dependencies = [
  "arrayref",
  "base64 0.22.1",
  "digest 0.9.0",
- "hmac-drbg",
  "libsecp256k1-core",
  "libsecp256k1-gen-ecmult",
  "libsecp256k1-gen-genmult",
  "rand 0.8.5",
  "serde",
  "sha2 0.9.9",
- "typenum",
 ]
 
 [[package]]
@@ -7039,12 +7100,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
-name = "lock_api"
-version = "0.4.12"
+name = "litemap"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
+
+[[package]]
+name = "lock_api"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
 dependencies = [
- "autocfg 1.4.0",
+ "autocfg 1.5.0",
  "scopeguard",
  "serde",
 ]
@@ -7083,7 +7150,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown 0.15.2",
+ "hashbrown 0.15.4",
 ]
 
 [[package]]
@@ -7092,8 +7159,14 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
 dependencies = [
- "hashbrown 0.15.2",
+ "hashbrown 0.15.4",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lz4"
@@ -7116,9 +7189,9 @@ dependencies = [
 
 [[package]]
 name = "lz4_flex"
-version = "0.11.3"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75761162ae2b0e580d7e7c390558127e5f01b4194debd6221fd8c207fc80e3f5"
+checksum = "08ab2867e3eeeca90e844d1940eab391c9dc5228783db2ed999acbc0a9ed375a"
 dependencies = [
  "twox-hash",
 ]
@@ -7131,9 +7204,9 @@ checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
 name = "mach2"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b955cdeb2a02b9117f121ce63aa52d08ade45de53e48fe6a38b39c10f6f709"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
 dependencies = [
  "libc",
 ]
@@ -7146,7 +7219,7 @@ checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -7184,9 +7257,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "memmap2"
@@ -7199,9 +7272,9 @@ dependencies = [
 
 [[package]]
 name = "memmap2"
-version = "0.9.5"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
+checksum = "483758ad303d734cec05e5c12b41d7e93e6a6390c5e9dae6bdeb7c1259012d28"
 dependencies = [
  "libc",
 ]
@@ -7212,7 +7285,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
- "autocfg 1.4.0",
+ "autocfg 1.5.0",
 ]
 
 [[package]]
@@ -7222,7 +7295,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b453bd8e35ec92138b093172731fe7920cdf397f2a709e789243147a79772b9d"
 dependencies = [
  "chrono",
- "clap 4.5.36",
+ "clap 4.5.41",
  "csv",
  "eyre",
  "indicatif",
@@ -7238,9 +7311,9 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a7deb012b3b2767169ff203fadb4c6b0b82b947512e5eb9e0b78c2e186ad9e3"
+checksum = "25dea7ac8057892855ec285c440160265225438c3c45072613c25a4b26e98ef5"
 dependencies = [
  "ahash",
  "portable-atomic",
@@ -7255,7 +7328,7 @@ dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
  "regex",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -7265,7 +7338,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd7399781913e5393588a8d8c6a2867bf85fb38eaf2502fdce465aad2dc6f034"
 dependencies = [
  "base64 0.22.1",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "metrics",
  "metrics-util",
  "quanta",
@@ -7290,16 +7363,16 @@ dependencies = [
 
 [[package]]
 name = "metrics-util"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbd4884b1dd24f7d6628274a2f5ae22465c337c5ba065ec9b6edccddf8acc673"
+checksum = "b8496cc523d1f94c1385dd8f0f0c2c480b2b8aeccb5b7e4485ad6365523ae376"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.4",
  "metrics",
  "quanta",
- "rand 0.8.5",
+ "rand 0.9.1",
  "rand_xoshiro",
  "sketches-ddsketch",
 ]
@@ -7310,7 +7383,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -7371,23 +7444,23 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
 ]
 
 [[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.52.0",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7414,7 +7487,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -7454,7 +7527,7 @@ dependencies = [
  "smallvec",
  "tagptr",
  "thiserror 1.0.69",
- "uuid 1.16.0",
+ "uuid 1.17.0",
 ]
 
 [[package]]
@@ -7538,7 +7611,7 @@ dependencies = [
  "core2",
  "digest 0.10.7",
  "multihash-derive",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "unsigned-varint 0.7.2",
 ]
 
@@ -7594,7 +7667,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -7644,12 +7717,11 @@ checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
 name = "notify"
-version = "8.0.0"
+version = "8.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fee8403b3d66ac7b26aee6e40a897d85dc5ce26f44da36b8b73e987cc52e943"
+checksum = "3163f59cd3fa0e9ef8c32f242966a7b9994fd7378366099593e0e73077cd8c97"
 dependencies = [
- "bitflags 2.9.0",
- "filetime",
+ "bitflags 2.9.1",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -7658,7 +7730,7 @@ dependencies = [
  "mio",
  "notify-types",
  "walkdir",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7767,7 +7839,7 @@ version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
 dependencies = [
- "autocfg 1.4.0",
+ "autocfg 1.5.0",
  "num-integer",
  "num-traits",
 ]
@@ -7789,39 +7861,40 @@ version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
- "autocfg 1.4.0",
+ "autocfg 1.5.0",
  "libm",
 ]
 
 [[package]]
 name = "num_cpus"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi 0.5.2",
  "libc",
 ]
 
 [[package]]
 name = "num_enum"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
+checksum = "a973b4e44ce6cad84ce69d797acf9a044532e4184c4f267913d1b546a0727b7a"
 dependencies = [
  "num_enum_derive",
+ "rustversion",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
+checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -7846,9 +7919,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8983bb634df7248924ee0c4c3a749609b5abcb082c28fffe3254b3eb3602b307"
 dependencies = [
  "alloy-rlp",
- "arbitrary",
  "const-hex",
  "proptest",
+ "serde",
+ "smallvec",
+]
+
+[[package]]
+name = "nybbles"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "675b3a54e5b12af997abc8b6638b0aee51a28caedab70d4967e0d5db3a3f1d06"
+dependencies = [
+ "alloy-rlp",
+ "arbitrary",
+ "cfg-if",
+ "proptest",
+ "ruint",
  "serde",
  "smallvec",
 ]
@@ -7873,6 +7960,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
 name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7880,15 +7973,15 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "op-alloy-consensus"
-version = "0.17.2"
+version = "0.18.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2423a125ef2daa0d15dacc361805a0b6f76d6acfc6e24a1ff6473582087fe75"
+checksum = "a8719d9b783b29cfa1cf8d591b894805786b9ab4940adc700a57fd0d5b721cf5"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.20",
+ "alloy-eips 1.0.20",
+ "alloy-primitives 1.2.1",
  "alloy-rlp",
- "alloy-serde 1.0.9",
+ "alloy-serde 1.0.20",
  "arbitrary",
  "derive_more 2.0.1",
  "serde",
@@ -7898,17 +7991,18 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-rpc-types-engine"
-version = "0.17.2"
+version = "0.18.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47aea08d8ad3f533df0c5082d3e93428a4c57898b7ade1be928fa03918f22e71"
+checksum = "6a4559d84f079b3fdfd01e4ee0bb118025e92105fbb89736f5d77ab3ca261698"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.20",
+ "alloy-eips 1.0.20",
+ "alloy-primitives 1.2.1",
  "alloy-rlp",
  "alloy-rpc-types-engine",
  "derive_more 2.0.1",
  "ethereum_ssz 0.9.0",
+ "ethereum_ssz_derive 0.9.0",
  "op-alloy-consensus",
  "snap",
  "thiserror 2.0.12",
@@ -7916,9 +8010,8 @@ dependencies = [
 
 [[package]]
 name = "op-revm"
-version = "5.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0e8a3830a2be82166fbe9ead34361149ff4320743ed7ee5502ab779de221361"
+version = "8.0.2"
+source = "git+https://github.com/bluealloy/revm?branch=rakita%2Feip7907#37edc381a940a52abb90b3e0a480292a675e8129"
 dependencies = [
  "auto_impl",
  "once_cell",
@@ -7959,11 +8052,11 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.72"
+version = "0.10.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
+checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -7980,7 +8073,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -7991,9 +8084,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.107"
+version = "0.9.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
+checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
 dependencies = [
  "cc",
  "libc",
@@ -8028,7 +8121,7 @@ dependencies = [
  "ecdsa 0.16.9",
  "elliptic-curve 0.13.8",
  "primeorder",
- "sha2 0.10.8",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -8043,9 +8136,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.7.4"
+version = "3.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9fde3d0718baf5bc92f577d652001da0f8d54cd03a7974e118d04fc888dc23d"
+checksum = "799781ae679d79a948e13d4824a40970bfa500058d245760dd857301059810fa"
 dependencies = [
  "arbitrary",
  "arrayvec",
@@ -8061,14 +8154,14 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.7.4"
+version = "3.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581c837bb6b9541ce7faa9377c20616e4fb7650f6b0f68bc93c827ee504fb7b3"
+checksum = "34b4653168b563151153c9e4c08ebed57fb8262bebfa79711552fa983c623e7a"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -8079,9 +8172,9 @@ checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -8089,9 +8182,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
@@ -8158,9 +8251,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
  "digest 0.10.7",
- "hmac 0.12.1",
+ "hmac",
  "password-hash",
- "sha2 0.10.8",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -8170,7 +8263,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest 0.10.7",
- "hmac 0.12.1",
+ "hmac",
 ]
 
 [[package]]
@@ -8209,9 +8302,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "198db74531d58c70a361c42201efde7e2591e976d518caf7662a47dc5720e7b6"
+checksum = "1db05f56d34358a8b1066f67cbb203ee3e7ed2ba674a6263a1d5ec6db2204323"
 dependencies = [
  "memchr",
  "thiserror 2.0.12",
@@ -8225,7 +8318,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
 ]
 
 [[package]]
@@ -8298,7 +8391,7 @@ dependencies = [
  "phf_shared 0.11.3",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -8336,7 +8429,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -8357,7 +8450,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
- "der 0.7.9",
+ "der 0.7.10",
  "pkcs8 0.10.2",
  "spki 0.7.3",
 ]
@@ -8378,7 +8471,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der 0.7.9",
+ "der 0.7.10",
  "spki 0.7.3",
 ]
 
@@ -8440,7 +8533,7 @@ version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1362d4a136c0ebacb40d88a37ba361738b222fd8a2ee9340a3d8642f698c52b"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "polars-core",
  "polars-io",
  "polars-lazy",
@@ -8473,12 +8566,12 @@ checksum = "b24f92fc5b167f668ff85ab9607dfa72e2c09664cacef59297ee8601dee60126"
 dependencies = [
  "ahash",
  "arrow2",
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "chrono",
  "comfy-table",
  "either",
  "hashbrown 0.14.5",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "num-traits",
  "once_cell",
  "polars-arrow",
@@ -8544,7 +8637,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c33762ec2a55e01c9f8776b34db86257c70a0a3b3929bd4eb91a52aacf61456"
 dependencies = [
  "ahash",
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "glob",
  "once_cell",
  "polars-arrow",
@@ -8569,7 +8662,7 @@ dependencies = [
  "argminmax",
  "arrow2",
  "either",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "memchr",
  "polars-arrow",
  "polars-core",
@@ -8703,9 +8796,18 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+dependencies = [
+ "zerovec 0.11.2",
+]
 
 [[package]]
 name = "powerfmt"
@@ -8719,7 +8821,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.8.24",
+ "zerocopy",
 ]
 
 [[package]]
@@ -8766,12 +8868,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.33"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dee91521343f4c5c6a63edd65e54f31f5c92fe8978c40a4282f8372194c6a7d"
+checksum = "061c1221631e079b26479d25bbf2275bfe5917ae8419cd7e34f13bfc2aa7539a"
 dependencies = [
  "proc-macro2 1.0.95",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -8799,13 +8901,13 @@ dependencies = [
 
 [[package]]
 name = "priority-queue"
-version = "2.3.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef08705fa1589a1a59aa924ad77d14722cb0cd97b67dd5004ed5f4a4873fce8d"
+checksum = "5676d703dda103cbb035b653a9f11448c0a7216c7926bd35fcb5865475d0c970"
 dependencies = [
- "autocfg 1.4.0",
+ "autocfg 1.5.0",
  "equivalent",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
 ]
 
 [[package]]
@@ -8870,7 +8972,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -8897,7 +8999,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc5b72d8145275d844d4b5f6d4e1eef00c8cd889edb6035c21675d1bb1f45c9f"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "chrono",
  "flate2",
  "hex",
@@ -8911,7 +9013,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "239df02d8349b06fc07398a3a1697b06418223b1c7725085e801e7c0fc6a12ec"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "chrono",
  "hex",
 ]
@@ -8933,18 +9035,18 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
+checksum = "6fcdab19deb5195a31cf7726a210015ff1496ba1464fd42cb4f537b8b01b471f"
 dependencies = [
  "bit-set 0.8.0",
  "bit-vec 0.8.0",
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "lazy_static",
  "num-traits",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
- "rand_xorshift 0.3.0",
+ "rand 0.9.1",
+ "rand_chacha 0.9.0",
+ "rand_xorshift 0.4.0",
  "regex-syntax 0.8.5",
  "rusty-fork",
  "tempfile",
@@ -8969,7 +9071,7 @@ checksum = "4ee1c9ac207483d5e7db4940700de86a9aae46ef90c48b57f99fe7edb8345e49"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -8984,22 +9086,22 @@ version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57206b407293d2bcd3af849ce869d52068623f19e1b5ff8e8778e3309439682b"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "memchr",
  "unicase",
 ]
 
 [[package]]
 name = "quanta"
-version = "0.12.5"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bd1fe6824cea6538803de3ff1bc0cf3949024db3d43c9643024bfb33a807c0e"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
 dependencies = [
  "crossbeam-utils",
  "libc",
  "once_cell",
  "raw-cpuid",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "web-sys",
  "winapi",
 ]
@@ -9021,21 +9123,21 @@ dependencies = [
 
 [[package]]
 name = "quick_cache"
-version = "0.6.13"
+version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "287e56aac5a2b4fb25a6fb050961d157635924c8696305a5c937a76f29841a0f"
+checksum = "6b450dad8382b1b95061d5ca1eb792081fb082adf48c678791fe917509596d5f"
 dependencies = [
  "ahash",
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.4",
  "parking_lot",
 ]
 
 [[package]]
 name = "quinn"
-version = "0.11.7"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3bd15a6f2967aef83887dcb9fec0014580467e33720d073560cf015a5683012"
+checksum = "626214629cda6781b6dc1d316ba307189c85ba657213ce642d9c77670f8202c8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -9043,7 +9145,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.1",
- "rustls 0.23.26",
+ "rustls 0.23.29",
  "socket2",
  "thiserror 2.0.12",
  "tokio",
@@ -9053,16 +9155,17 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.10"
+version = "0.11.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b820744eb4dc9b57a3398183639c511b5a26d2ed702cedd3febaa1393caa22cc"
+checksum = "49df843a9161c85bb8aae55f101bc0bac8bcafd637a620d9122fd7e0b2f7422e"
 dependencies = [
  "bytes",
- "getrandom 0.3.2",
- "rand 0.9.0",
+ "getrandom 0.3.3",
+ "lru-slab",
+ "rand 0.9.1",
  "ring 0.17.14",
  "rustc-hash 2.1.1",
- "rustls 0.23.26",
+ "rustls 0.23.29",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.12",
@@ -9073,9 +9176,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.11"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "541d0f57c6ec747a90738a52741d3221f7960e8ac2f0ff4b1a63680e033b4ab5"
+checksum = "fcebb1209ee276352ef14ff8732e24cc2b02bbac986cd74a4c81bcb2f9881970"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -9105,9 +9208,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "radium"
@@ -9161,14 +9264,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
  "serde",
- "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -9241,7 +9343,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -9250,7 +9352,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
  "serde",
 ]
 
@@ -9337,20 +9439,20 @@ dependencies = [
 
 [[package]]
 name = "rand_xorshift"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
 name = "rand_xoshiro"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -9359,7 +9461,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "cassowary",
  "compact_str",
  "crossterm",
@@ -9380,7 +9482,7 @@ version = "11.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6df7ab838ed27997ba19a4664507e6f82b41fe6e20be42929332156e5e85146"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -9409,27 +9511,27 @@ version = "0.1.0"
 dependencies = [
  "ahash",
  "alloy-chains",
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
+ "alloy-consensus 1.0.20",
+ "alloy-eips 1.0.20",
  "alloy-evm",
- "alloy-json-rpc 1.0.9",
+ "alloy-json-rpc 1.0.20",
  "alloy-network",
- "alloy-network-primitives 1.0.9",
+ "alloy-network-primitives 1.0.20",
  "alloy-node-bindings",
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.2.1",
  "alloy-provider",
  "alloy-rlp",
  "alloy-rpc-types",
  "alloy-rpc-types-beacon",
  "alloy-rpc-types-engine",
- "alloy-rpc-types-eth 1.0.9",
+ "alloy-rpc-types-eth 1.0.20",
  "alloy-signer-local",
  "assert_matches",
  "async-trait",
  "beacon-api-client",
  "bigdecimal 0.4.8",
  "built",
- "clap 4.5.36",
+ "clap 4.5.41",
  "criterion 0.5.1",
  "crossbeam",
  "crossbeam-queue",
@@ -9466,12 +9568,13 @@ dependencies = [
  "rand 0.8.5",
  "rayon",
  "reipc",
- "reqwest 0.12.15",
+ "reqwest 0.12.22",
  "reth",
  "reth-chainspec",
  "reth-db",
  "reth-db-common",
  "reth-errors",
+ "reth-ethereum-primitives",
  "reth-evm",
  "reth-evm-ethereum",
  "reth-node-api",
@@ -9485,11 +9588,11 @@ dependencies = [
  "reth-trie-parallel",
  "revm",
  "revm-inspectors",
- "secp256k1",
+ "secp256k1 0.30.0",
  "serde",
  "serde_json",
  "serde_with",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "shellexpand",
  "sqlx",
  "sysperf",
@@ -9501,11 +9604,11 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "toml 0.8.20",
+ "toml 0.8.23",
  "tracing",
  "tracing-subscriber 0.3.19",
  "url",
- "uuid 1.16.0",
+ "uuid 1.17.0",
  "warp",
 ]
 
@@ -9526,11 +9629,11 @@ checksum = "d3edd4d5d42c92f0a659926464d4cce56b562761267ecf0f469d85b7de384175"
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.11"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
+checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -9539,7 +9642,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "libredox",
  "thiserror 1.0.69",
 ]
@@ -9550,9 +9653,29 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "libredox",
  "thiserror 2.0.12",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
+dependencies = [
+ "proc-macro2 1.0.95",
+ "quote 1.0.40",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -9601,11 +9724,11 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "regress"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ef7fa9ed0256d64a688a3747d0fef7a88851c18a5e1d57f115f38ec2e09366"
+checksum = "145bb27393fe455dd64d6cbc8d059adfa392590a45eadf079c01b11857e7b010"
 dependencies = [
- "hashbrown 0.15.2",
+ "hashbrown 0.15.4",
  "memchr",
 ]
 
@@ -9637,7 +9760,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.3.26",
+ "h2 0.3.27",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.32",
@@ -9652,7 +9775,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls 0.21.12",
- "rustls-pemfile 1.0.4",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -9674,9 +9797,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.15"
+version = "0.12.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
+checksum = "cbc931937e6ca3a06e3b6c0aa7841849b160a90351d6ab467a8b9b9959767531"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -9684,64 +9807,57 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.9",
+ "h2 0.4.11",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.6.0",
- "hyper-rustls 0.27.5",
+ "hyper-rustls 0.27.7",
  "hyper-tls 0.6.0",
  "hyper-util",
- "ipnet",
  "js-sys",
  "log",
  "mime",
  "native-tls",
- "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.26",
+ "rustls 0.23.29",
  "rustls-native-certs 0.8.1",
- "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 1.0.2",
- "system-configuration 0.6.1",
  "tokio",
  "tokio-native-tls",
  "tokio-rustls 0.26.2",
  "tokio-util",
  "tower 0.5.2",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 0.26.8",
- "windows-registry",
+ "webpki-roots 1.0.1",
 ]
 
 [[package]]
 name = "resolv-conf"
-version = "0.7.1"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48375394603e3dd4b2d64371f7148fd8c7baa2680e28741f2cb8d23b59e3d4c4"
-dependencies = [
- "hostname",
-]
+checksum = "95325155c684b1c89f7765e30bc1c42e4a6da51ca513615660cb8a62ef9a88e3"
 
 [[package]]
 name = "reth"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
  "alloy-rpc-types",
  "aquamarine",
- "clap 4.5.36",
+ "clap 4.5.41",
  "eyre",
  "reth-chainspec",
  "reth-cli-runner",
@@ -9770,9 +9886,9 @@ dependencies = [
  "reth-rpc",
  "reth-rpc-api",
  "reth-rpc-builder",
+ "reth-rpc-convert",
  "reth-rpc-eth-types",
  "reth-rpc-server-types",
- "reth-rpc-types-compat",
  "reth-tasks",
  "reth-tokio-util",
  "reth-transaction-pool",
@@ -9782,12 +9898,12 @@ dependencies = [
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.20",
+ "alloy-eips 1.0.20",
+ "alloy-primitives 1.2.1",
  "futures-core",
  "futures-util",
  "metrics",
@@ -9806,19 +9922,19 @@ dependencies = [
 
 [[package]]
 name = "reth-chain-state"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.20",
+ "alloy-eips 1.0.20",
+ "alloy-primitives 1.2.1",
  "alloy-signer",
  "alloy-signer-local",
  "derive_more 2.0.1",
  "metrics",
  "parking_lot",
  "pin-project",
- "rand 0.9.0",
+ "rand 0.9.1",
  "reth-chainspec",
  "reth-errors",
  "reth-ethereum-primitives",
@@ -9837,16 +9953,16 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
  "alloy-chains",
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
+ "alloy-consensus 1.0.20",
+ "alloy-eips 1.0.20",
  "alloy-evm",
  "alloy-genesis",
- "alloy-primitives 1.2.0",
- "alloy-trie 0.8.1",
+ "alloy-primitives 1.2.1",
+ "alloy-trie 0.9.0",
  "auto_impl",
  "derive_more 2.0.1",
  "reth-ethereum-forks",
@@ -9857,11 +9973,11 @@ dependencies = [
 
 [[package]]
 name = "reth-cli"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
  "alloy-genesis",
- "clap 4.5.36",
+ "clap 4.5.41",
  "eyre",
  "reth-cli-runner",
  "reth-db",
@@ -9871,17 +9987,17 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-commands"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
  "ahash",
  "alloy-chains",
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.20",
+ "alloy-eips 1.0.20",
+ "alloy-primitives 1.2.1",
  "alloy-rlp",
  "backon",
- "clap 4.5.36",
+ "clap 4.5.41",
  "comfy-table",
  "crossterm",
  "eyre",
@@ -9891,7 +10007,7 @@ dependencies = [
  "itertools 0.14.0",
  "lz4",
  "ratatui",
- "reqwest 0.12.15",
+ "reqwest 0.12.22",
  "reth-chainspec",
  "reth-cli",
  "reth-cli-runner",
@@ -9930,20 +10046,20 @@ dependencies = [
  "reth-static-file-types",
  "reth-trie",
  "reth-trie-db",
- "secp256k1",
+ "secp256k1 0.30.0",
  "serde",
  "serde_json",
  "tar",
  "tokio",
  "tokio-stream",
- "toml 0.8.20",
+ "toml 0.8.23",
  "tracing",
 ]
 
 [[package]]
 name = "reth-cli-runner"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -9952,17 +10068,17 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-util"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-eips 1.0.20",
+ "alloy-primitives 1.2.1",
  "cfg-if",
  "eyre",
  "libc",
  "rand 0.8.5",
  "reth-fs-util",
- "secp256k1",
+ "secp256k1 0.30.0",
  "serde",
  "thiserror 2.0.12",
  "tikv-jemallocator",
@@ -9970,14 +10086,14 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
+ "alloy-consensus 1.0.20",
+ "alloy-eips 1.0.20",
  "alloy-genesis",
- "alloy-primitives 1.2.0",
- "alloy-trie 0.8.1",
+ "alloy-primitives 1.2.1",
+ "alloy-trie 0.9.0",
  "arbitrary",
  "bytes",
  "modular-bitfield",
@@ -9990,19 +10106,19 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
  "convert_case 0.7.1",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "reth-config"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -10010,16 +10126,17 @@ dependencies = [
  "reth-prune-types",
  "reth-stages-types",
  "serde",
- "toml 0.8.20",
+ "toml 0.8.23",
+ "url",
 ]
 
 [[package]]
 name = "reth-consensus"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.20",
+ "alloy-primitives 1.2.1",
  "auto_impl",
  "reth-execution-types",
  "reth-primitives-traits",
@@ -10028,11 +10145,11 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
+ "alloy-consensus 1.0.20",
+ "alloy-eips 1.0.20",
  "reth-chainspec",
  "reth-consensus",
  "reth-primitives-traits",
@@ -10040,20 +10157,20 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-debug-client"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-json-rpc 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.20",
+ "alloy-eips 1.0.20",
+ "alloy-json-rpc 1.0.20",
+ "alloy-primitives 1.2.1",
  "alloy-provider",
  "alloy-rpc-types-engine",
  "auto_impl",
  "derive_more 2.0.1",
  "eyre",
  "futures",
- "reqwest 0.12.15",
+ "reqwest 0.12.22",
  "reth-node-api",
  "reth-primitives-traits",
  "reth-tracing",
@@ -10064,10 +10181,10 @@ dependencies = [
 
 [[package]]
 name = "reth-db"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.2.1",
  "derive_more 2.0.1",
  "eyre",
  "metrics",
@@ -10090,12 +10207,12 @@ dependencies = [
 
 [[package]]
 name = "reth-db-api"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-consensus 1.0.9",
+ "alloy-consensus 1.0.20",
  "alloy-genesis",
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.2.1",
  "arbitrary",
  "bytes",
  "derive_more 2.0.1",
@@ -10118,12 +10235,12 @@ dependencies = [
 
 [[package]]
 name = "reth-db-common"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-consensus 1.0.9",
+ "alloy-consensus 1.0.20",
  "alloy-genesis",
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.2.1",
  "boyer-moore-magiclen",
  "eyre",
  "reth-chainspec",
@@ -10147,11 +10264,11 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-eips 1.0.20",
+ "alloy-primitives 1.2.1",
  "arbitrary",
  "bytes",
  "modular-bitfield",
@@ -10162,10 +10279,10 @@ dependencies = [
 
 [[package]]
 name = "reth-discv4"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.2.1",
  "alloy-rlp",
  "discv5",
  "enr 0.13.0",
@@ -10178,7 +10295,7 @@ dependencies = [
  "reth-net-nat",
  "reth-network-peers",
  "schnellru",
- "secp256k1",
+ "secp256k1 0.30.0",
  "serde",
  "thiserror 2.0.12",
  "tokio",
@@ -10188,10 +10305,10 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.2.1",
  "alloy-rlp",
  "derive_more 2.0.1",
  "discv5",
@@ -10199,12 +10316,12 @@ dependencies = [
  "futures",
  "itertools 0.14.0",
  "metrics",
- "rand 0.9.0",
+ "rand 0.9.1",
  "reth-chainspec",
  "reth-ethereum-forks",
  "reth-metrics",
  "reth-network-peers",
- "secp256k1",
+ "secp256k1 0.30.0",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -10212,10 +10329,10 @@ dependencies = [
 
 [[package]]
 name = "reth-dns-discovery"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.2.1",
  "data-encoding",
  "enr 0.13.0",
  "hickory-resolver",
@@ -10225,7 +10342,7 @@ dependencies = [
  "reth-network-peers",
  "reth-tokio-util",
  "schnellru",
- "secp256k1",
+ "secp256k1 0.30.0",
  "serde",
  "serde_with",
  "thiserror 2.0.12",
@@ -10236,12 +10353,12 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.20",
+ "alloy-eips 1.0.20",
+ "alloy-primitives 1.2.1",
  "alloy-rlp",
  "futures",
  "futures-util",
@@ -10266,11 +10383,11 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
  "aes",
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.2.1",
  "alloy-rlp",
  "block-padding",
  "byteorder",
@@ -10280,12 +10397,12 @@ dependencies = [
  "digest 0.10.7",
  "futures",
  "generic-array",
- "hmac 0.12.1",
+ "hmac",
  "pin-project",
  "rand 0.8.5",
  "reth-network-peers",
- "secp256k1",
- "sha2 0.10.8",
+ "secp256k1 0.30.0",
+ "sha2 0.10.9",
  "sha3",
  "thiserror 2.0.12",
  "tokio",
@@ -10297,27 +10414,20 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-local"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.20",
+ "alloy-primitives 1.2.1",
  "alloy-rpc-types-engine",
  "eyre",
  "futures-util",
  "reth-chainspec",
- "reth-consensus",
  "reth-engine-primitives",
- "reth-engine-service",
- "reth-engine-tree",
  "reth-ethereum-engine-primitives",
- "reth-evm",
- "reth-node-types",
  "reth-payload-builder",
  "reth-payload-primitives",
  "reth-provider",
- "reth-prune",
- "reth-stages-api",
  "reth-transaction-pool",
  "tokio",
  "tokio-stream",
@@ -10326,11 +10436,12 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.20",
+ "alloy-eips 1.0.20",
+ "alloy-primitives 1.2.1",
  "alloy-rpc-types-engine",
  "auto_impl",
  "futures",
@@ -10350,8 +10461,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-service"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
  "futures",
  "pin-project",
@@ -10373,13 +10484,13 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-tree"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
+ "alloy-consensus 1.0.20",
+ "alloy-eips 1.0.20",
  "alloy-evm",
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.2.1",
  "alloy-rlp",
  "alloy-rpc-types-engine",
  "derive_more 2.0.1",
@@ -10420,10 +10531,10 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-util"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-consensus 1.0.9",
+ "alloy-consensus 1.0.20",
  "alloy-rpc-types-engine",
  "eyre",
  "futures",
@@ -10447,12 +10558,12 @@ dependencies = [
 
 [[package]]
 name = "reth-era"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.20",
+ "alloy-eips 1.0.20",
+ "alloy-primitives 1.2.1",
  "alloy-rlp",
  "ethereum_ssz 0.9.0",
  "ethereum_ssz_derive 0.9.0",
@@ -10463,34 +10574,38 @@ dependencies = [
 
 [[package]]
 name = "reth-era-downloader"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.2.1",
  "bytes",
  "eyre",
  "futures-util",
- "reqwest 0.12.15",
+ "reqwest 0.12.22",
  "reth-fs-util",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "tokio",
 ]
 
 [[package]]
 name = "reth-era-utils"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.20",
+ "alloy-primitives 1.2.1",
+ "alloy-rlp",
  "eyre",
  "futures-util",
  "reth-db-api",
  "reth-era",
  "reth-era-downloader",
+ "reth-ethereum-primitives",
  "reth-etl",
  "reth-fs-util",
  "reth-primitives-traits",
  "reth-provider",
+ "reth-stages-types",
  "reth-storage-api",
  "tokio",
  "tracing",
@@ -10498,8 +10613,8 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -10509,11 +10624,11 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
  "alloy-chains",
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.2.1",
  "alloy-rlp",
  "bytes",
  "derive_more 2.0.1",
@@ -10537,14 +10652,14 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
  "alloy-chains",
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
+ "alloy-consensus 1.0.20",
+ "alloy-eips 1.0.20",
  "alloy-hardforks",
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.2.1",
  "alloy-rlp",
  "bytes",
  "derive_more 2.0.1",
@@ -10558,16 +10673,16 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-cli"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.20",
+ "alloy-eips 1.0.20",
+ "alloy-primitives 1.2.1",
  "alloy-rlp",
  "alloy-rpc-types",
  "backon",
- "clap 4.5.36",
+ "clap 4.5.41",
  "eyre",
  "futures",
  "reth-basic-payload-builder",
@@ -10617,12 +10732,12 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.20",
+ "alloy-eips 1.0.20",
+ "alloy-primitives 1.2.1",
  "reth-chainspec",
  "reth-consensus",
  "reth-consensus-common",
@@ -10633,11 +10748,11 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-eips 1.0.20",
+ "alloy-primitives 1.2.1",
  "alloy-rlp",
  "alloy-rpc-types-engine",
  "reth-engine-primitives",
@@ -10645,18 +10760,18 @@ dependencies = [
  "reth-payload-primitives",
  "reth-primitives-traits",
  "serde",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
  "alloy-eip2124 0.2.0",
  "alloy-hardforks",
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.2.1",
  "auto_impl",
  "once_cell",
  "rustc-hash 2.1.1",
@@ -10664,15 +10779,17 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.20",
+ "alloy-eips 1.0.20",
+ "alloy-primitives 1.2.1",
+ "alloy-rlp",
  "alloy-rpc-types-engine",
  "reth-basic-payload-builder",
  "reth-chainspec",
+ "reth-consensus-common",
  "reth-errors",
  "reth-ethereum-primitives",
  "reth-evm",
@@ -10691,12 +10808,12 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.20",
+ "alloy-eips 1.0.20",
+ "alloy-primitives 1.2.1",
  "alloy-rlp",
  "arbitrary",
  "modular-bitfield",
@@ -10709,8 +10826,8 @@ dependencies = [
 
 [[package]]
 name = "reth-etl"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -10719,13 +10836,13 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
+ "alloy-consensus 1.0.20",
+ "alloy-eips 1.0.20",
  "alloy-evm",
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.2.1",
  "auto_impl",
  "derive_more 2.0.1",
  "futures-util",
@@ -10742,13 +10859,13 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
+ "alloy-consensus 1.0.20",
+ "alloy-eips 1.0.20",
  "alloy-evm",
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.2.1",
  "derive_more 2.0.1",
  "reth-chainspec",
  "reth-ethereum-forks",
@@ -10761,26 +10878,26 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
  "alloy-evm",
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.2.1",
  "alloy-rlp",
- "nybbles",
+ "nybbles 0.4.1",
  "reth-storage-errors",
  "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "reth-execution-types"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
+ "alloy-consensus 1.0.20",
+ "alloy-eips 1.0.20",
  "alloy-evm",
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.2.1",
  "derive_more 2.0.1",
  "reth-ethereum-primitives",
  "reth-primitives-traits",
@@ -10792,12 +10909,12 @@ dependencies = [
 
 [[package]]
 name = "reth-exex"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.20",
+ "alloy-eips 1.0.20",
+ "alloy-primitives 1.2.1",
  "eyre",
  "futures",
  "itertools 0.14.0",
@@ -10830,11 +10947,11 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-types"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-eips 1.0.20",
+ "alloy-primitives 1.2.1",
  "reth-chain-state",
  "reth-execution-types",
  "reth-primitives-traits",
@@ -10844,8 +10961,8 @@ dependencies = [
 
 [[package]]
 name = "reth-fs-util"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
  "serde",
  "serde_json",
@@ -10854,11 +10971,11 @@ dependencies = [
 
 [[package]]
 name = "reth-invalid-block-hooks"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.20",
+ "alloy-primitives 1.2.1",
  "alloy-rlp",
  "alloy-rpc-types-debug",
  "eyre",
@@ -10882,8 +10999,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ipc"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
  "bytes",
  "futures",
@@ -10902,14 +11019,14 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "byteorder",
  "dashmap 6.1.0",
  "derive_more 2.0.1",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "parking_lot",
  "reth-mdbx-sys",
  "smallvec",
@@ -10919,8 +11036,8 @@ dependencies = [
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
  "bindgen",
  "cc",
@@ -10928,8 +11045,8 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
  "futures",
  "metrics",
@@ -10940,20 +11057,20 @@ dependencies = [
 
 [[package]]
 name = "reth-net-banlist"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.2.1",
 ]
 
 [[package]]
 name = "reth-net-nat"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
  "futures-util",
  "if-addrs",
- "reqwest 0.12.15",
+ "reqwest 0.12.22",
  "serde_with",
  "thiserror 2.0.12",
  "tokio",
@@ -10962,12 +11079,12 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.20",
+ "alloy-eips 1.0.20",
+ "alloy-primitives 1.2.1",
  "alloy-rlp",
  "aquamarine",
  "auto_impl",
@@ -10980,7 +11097,7 @@ dependencies = [
  "parking_lot",
  "pin-project",
  "rand 0.8.5",
- "rand 0.9.0",
+ "rand 0.9.1",
  "reth-chainspec",
  "reth-consensus",
  "reth-discv4",
@@ -11005,7 +11122,7 @@ dependencies = [
  "reth-transaction-pool",
  "rustc-hash 2.1.1",
  "schnellru",
- "secp256k1",
+ "secp256k1 0.30.0",
  "serde",
  "smallvec",
  "thiserror 2.0.12",
@@ -11017,10 +11134,10 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.2.1",
  "alloy-rpc-types-admin",
  "auto_impl",
  "derive_more 2.0.1",
@@ -11040,12 +11157,12 @@ dependencies = [
 
 [[package]]
 name = "reth-network-p2p"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.20",
+ "alloy-eips 1.0.20",
+ "alloy-primitives 1.2.1",
  "auto_impl",
  "derive_more 2.0.1",
  "futures",
@@ -11062,13 +11179,13 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.2.1",
  "alloy-rlp",
  "enr 0.13.0",
- "secp256k1",
+ "secp256k1 0.30.0",
  "serde_with",
  "thiserror 2.0.12",
  "tokio",
@@ -11077,8 +11194,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
  "alloy-eip2124 0.2.0",
  "humantime-serde",
@@ -11091,14 +11208,14 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
  "anyhow",
  "bincode",
  "derive_more 2.0.1",
  "lz4_flex",
- "memmap2 0.9.5",
+ "memmap2 0.9.7",
  "reth-fs-util",
  "serde",
  "thiserror 2.0.12",
@@ -11108,8 +11225,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -11132,12 +11249,12 @@ dependencies = [
 
 [[package]]
 name = "reth-node-builder"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.20",
+ "alloy-eips 1.0.20",
+ "alloy-primitives 1.2.1",
  "alloy-provider",
  "alloy-rpc-types",
  "alloy-rpc-types-engine",
@@ -11187,7 +11304,7 @@ dependencies = [
  "reth-tokio-util",
  "reth-tracing",
  "reth-transaction-pool",
- "secp256k1",
+ "secp256k1 0.30.0",
  "serde_json",
  "tokio",
  "tokio-stream",
@@ -11196,20 +11313,20 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.20",
+ "alloy-eips 1.0.20",
+ "alloy-primitives 1.2.1",
  "alloy-rpc-types-engine",
- "clap 4.5.36",
+ "clap 4.5.41",
  "derive_more 2.0.1",
  "dirs-next",
  "eyre",
  "futures",
  "humantime",
- "rand 0.9.0",
+ "rand 0.9.1",
  "reth-chainspec",
  "reth-cli-util",
  "reth-config",
@@ -11225,33 +11342,34 @@ dependencies = [
  "reth-network-peers",
  "reth-primitives-traits",
  "reth-prune-types",
+ "reth-rpc-convert",
  "reth-rpc-eth-types",
  "reth-rpc-server-types",
- "reth-rpc-types-compat",
  "reth-stages-types",
  "reth-storage-api",
  "reth-storage-errors",
  "reth-tracing",
  "reth-transaction-pool",
- "secp256k1",
+ "secp256k1 0.30.0",
  "serde",
  "shellexpand",
  "strum 0.27.1",
  "thiserror 2.0.12",
- "toml 0.8.20",
+ "toml 0.8.23",
  "tracing",
+ "url",
  "vergen",
  "vergen-git2",
 ]
 
 [[package]]
 name = "reth-node-ethereum"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-eips 1.0.9",
+ "alloy-eips 1.0.20",
  "alloy-rpc-types-engine",
- "alloy-rpc-types-eth 1.0.9",
+ "alloy-rpc-types-eth 1.0.20",
  "eyre",
  "reth-chainspec",
  "reth-consensus",
@@ -11282,12 +11400,12 @@ dependencies = [
 
 [[package]]
 name = "reth-node-events"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.20",
+ "alloy-eips 1.0.20",
+ "alloy-primitives 1.2.1",
  "alloy-rpc-types-engine",
  "derive_more 2.0.1",
  "futures",
@@ -11306,8 +11424,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-metrics"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
  "eyre",
  "http 1.3.1",
@@ -11327,8 +11445,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-types"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -11340,12 +11458,12 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-primitives"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.20",
+ "alloy-eips 1.0.20",
+ "alloy-primitives 1.2.1",
  "alloy-rlp",
  "arbitrary",
  "bytes",
@@ -11359,10 +11477,10 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-consensus 1.0.9",
+ "alloy-consensus 1.0.20",
  "alloy-rpc-types",
  "futures-util",
  "metrics",
@@ -11379,8 +11497,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder-primitives"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -11391,11 +11509,11 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-eips 1.0.20",
+ "alloy-primitives 1.2.1",
  "alloy-rpc-types-engine",
  "auto_impl",
  "op-alloy-rpc-types-engine",
@@ -11410,20 +11528,20 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-consensus 1.0.9",
+ "alloy-consensus 1.0.20",
  "alloy-rpc-types-engine",
  "reth-primitives-traits",
 ]
 
 [[package]]
 name = "reth-primitives"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-consensus 1.0.9",
+ "alloy-consensus 1.0.20",
  "c-kzg",
  "once_cell",
  "reth-ethereum-forks",
@@ -11434,15 +11552,16 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
+ "alloy-consensus 1.0.20",
+ "alloy-eips 1.0.20",
  "alloy-genesis",
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.2.1",
  "alloy-rlp",
- "alloy-trie 0.8.1",
+ "alloy-rpc-types-eth 1.0.20",
+ "alloy-trie 0.9.0",
  "arbitrary",
  "auto_impl",
  "byteorder",
@@ -11458,7 +11577,7 @@ dependencies = [
  "revm-bytecode",
  "revm-primitives",
  "revm-state",
- "secp256k1",
+ "secp256k1 0.30.0",
  "serde",
  "serde_with",
  "thiserror 2.0.12",
@@ -11466,12 +11585,12 @@ dependencies = [
 
 [[package]]
 name = "reth-provider"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.20",
+ "alloy-eips 1.0.20",
+ "alloy-primitives 1.2.1",
  "alloy-rpc-types-engine",
  "dashmap 6.1.0",
  "eyre",
@@ -11511,12 +11630,12 @@ dependencies = [
 
 [[package]]
 name = "reth-prune"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.20",
+ "alloy-eips 1.0.20",
+ "alloy-primitives 1.2.1",
  "itertools 0.14.0",
  "metrics",
  "rayon",
@@ -11539,10 +11658,10 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.2.1",
  "arbitrary",
  "derive_more 2.0.1",
  "modular-bitfield",
@@ -11556,7 +11675,7 @@ name = "reth-rbuilder"
 version = "0.1.0"
 dependencies = [
  "alloy-rlp",
- "clap 4.5.36",
+ "clap 4.5.41",
  "eyre",
  "libc",
  "rbuilder",
@@ -11572,11 +11691,11 @@ dependencies = [
 
 [[package]]
 name = "reth-ress-protocol"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.20",
+ "alloy-primitives 1.2.1",
  "alloy-rlp",
  "futures",
  "reth-eth-wire",
@@ -11591,11 +11710,11 @@ dependencies = [
 
 [[package]]
 name = "reth-ress-provider"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.20",
+ "alloy-primitives 1.2.1",
  "eyre",
  "futures",
  "parking_lot",
@@ -11618,10 +11737,10 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.2.1",
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-storage-errors",
@@ -11631,27 +11750,27 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-consensus 1.0.9",
+ "alloy-consensus 1.0.20",
  "alloy-dyn-abi",
- "alloy-eips 1.0.9",
+ "alloy-eips 1.0.20",
  "alloy-evm",
  "alloy-genesis",
  "alloy-network",
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.2.1",
  "alloy-rlp",
  "alloy-rpc-types",
  "alloy-rpc-types-admin",
  "alloy-rpc-types-beacon",
  "alloy-rpc-types-debug",
  "alloy-rpc-types-engine",
- "alloy-rpc-types-eth 1.0.9",
+ "alloy-rpc-types-eth 1.0.20",
  "alloy-rpc-types-mev",
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
- "alloy-serde 1.0.9",
+ "alloy-serde 1.0.20",
  "alloy-signer",
  "alloy-signer-local",
  "async-trait",
@@ -11672,6 +11791,7 @@ dependencies = [
  "reth-errors",
  "reth-ethereum-primitives",
  "reth-evm",
+ "reth-evm-ethereum",
  "reth-execution-types",
  "reth-metrics",
  "reth-network-api",
@@ -11681,11 +11801,11 @@ dependencies = [
  "reth-primitives-traits",
  "reth-revm",
  "reth-rpc-api",
+ "reth-rpc-convert",
  "reth-rpc-engine-api",
  "reth-rpc-eth-api",
  "reth-rpc-eth-types",
  "reth-rpc-server-types",
- "reth-rpc-types-compat",
  "reth-storage-api",
  "reth-tasks",
  "reth-transaction-pool",
@@ -11695,7 +11815,7 @@ dependencies = [
  "revm-primitives",
  "serde",
  "serde_json",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
@@ -11706,24 +11826,24 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-eips 1.0.9",
+ "alloy-eips 1.0.20",
  "alloy-genesis",
- "alloy-json-rpc 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-json-rpc 1.0.20",
+ "alloy-primitives 1.2.1",
  "alloy-rpc-types",
  "alloy-rpc-types-admin",
  "alloy-rpc-types-anvil",
  "alloy-rpc-types-beacon",
  "alloy-rpc-types-debug",
  "alloy-rpc-types-engine",
- "alloy-rpc-types-eth 1.0.9",
+ "alloy-rpc-types-eth 1.0.20",
  "alloy-rpc-types-mev",
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
- "alloy-serde 1.0.9",
+ "alloy-serde 1.0.20",
  "jsonrpsee 0.25.1",
  "reth-chain-state",
  "reth-engine-primitives",
@@ -11734,8 +11854,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-builder"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -11771,12 +11891,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-rpc-engine-api"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+name = "reth-rpc-convert"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.20",
+ "alloy-json-rpc 1.0.20",
+ "alloy-network",
+ "alloy-primitives 1.2.1",
+ "alloy-rpc-types-eth 1.0.20",
+ "jsonrpsee-types 0.25.1",
+ "reth-evm",
+ "reth-primitives-traits",
+ "revm-context",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "reth-rpc-engine-api"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
+dependencies = [
+ "alloy-eips 1.0.20",
+ "alloy-primitives 1.2.1",
  "alloy-rpc-types-engine",
  "async-trait",
  "jsonrpsee-core 0.25.1",
@@ -11802,19 +11939,20 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-api"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-consensus 1.0.9",
+ "alloy-consensus 1.0.20",
  "alloy-dyn-abi",
- "alloy-eips 1.0.9",
- "alloy-json-rpc 1.0.9",
+ "alloy-eips 1.0.20",
+ "alloy-evm",
+ "alloy-json-rpc 1.0.20",
  "alloy-network",
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.2.1",
  "alloy-rlp",
- "alloy-rpc-types-eth 1.0.9",
+ "alloy-rpc-types-eth 1.0.20",
  "alloy-rpc-types-mev",
- "alloy-serde 1.0.9",
+ "alloy-serde 1.0.20",
  "async-trait",
  "auto_impl",
  "dyn-clone",
@@ -11822,6 +11960,7 @@ dependencies = [
  "jsonrpsee 0.25.1",
  "jsonrpsee-types 0.25.1",
  "parking_lot",
+ "reth-chain-state",
  "reth-chainspec",
  "reth-errors",
  "reth-evm",
@@ -11830,9 +11969,9 @@ dependencies = [
  "reth-payload-builder",
  "reth-primitives-traits",
  "reth-revm",
+ "reth-rpc-convert",
  "reth-rpc-eth-types",
  "reth-rpc-server-types",
- "reth-rpc-types-compat",
  "reth-storage-api",
  "reth-tasks",
  "reth-transaction-pool",
@@ -11845,21 +11984,22 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-types"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
- "alloy-rpc-types-eth 1.0.9",
- "alloy-sol-types 1.2.0",
+ "alloy-consensus 1.0.20",
+ "alloy-eips 1.0.20",
+ "alloy-evm",
+ "alloy-primitives 1.2.1",
+ "alloy-rpc-types-eth 1.0.20",
+ "alloy-sol-types 1.2.1",
  "derive_more 2.0.1",
  "futures",
  "itertools 0.14.0",
  "jsonrpsee-core 0.25.1",
  "jsonrpsee-types 0.25.1",
  "metrics",
- "rand 0.9.0",
+ "rand 0.9.1",
  "reth-chain-state",
  "reth-chainspec",
  "reth-errors",
@@ -11869,8 +12009,8 @@ dependencies = [
  "reth-metrics",
  "reth-primitives-traits",
  "reth-revm",
+ "reth-rpc-convert",
  "reth-rpc-server-types",
- "reth-rpc-types-compat",
  "reth-storage-api",
  "reth-tasks",
  "reth-transaction-pool",
@@ -11887,8 +12027,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-layer"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.3.1",
@@ -11901,11 +12041,11 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-eips 1.0.20",
+ "alloy-primitives 1.2.1",
  "alloy-rpc-types-engine",
  "jsonrpsee-core 0.25.1",
  "jsonrpsee-types 0.25.1",
@@ -11916,38 +12056,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-rpc-types-compat"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
-dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-primitives 1.2.0",
- "alloy-rpc-types-eth 1.0.9",
- "jsonrpsee-types 0.25.1",
- "reth-primitives-traits",
- "serde",
-]
-
-[[package]]
 name = "reth-stages"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.20",
+ "alloy-eips 1.0.20",
+ "alloy-primitives 1.2.1",
  "bincode",
  "blake3",
+ "eyre",
  "futures-util",
  "itertools 0.14.0",
  "num-traits",
  "rayon",
- "reqwest 0.12.15",
+ "reqwest 0.12.22",
  "reth-codecs",
  "reth-config",
  "reth-consensus",
  "reth-db",
  "reth-db-api",
+ "reth-era",
+ "reth-era-downloader",
+ "reth-era-utils",
  "reth-etl",
  "reth-evm",
  "reth-execution-types",
@@ -11972,11 +12103,11 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-api"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-eips 1.0.20",
+ "alloy-primitives 1.2.1",
  "aquamarine",
  "auto_impl",
  "futures-util",
@@ -11999,10 +12130,10 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.2.1",
  "arbitrary",
  "bytes",
  "modular-bitfield",
@@ -12013,10 +12144,10 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.2.1",
  "parking_lot",
  "rayon",
  "reth-codecs",
@@ -12033,11 +12164,11 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-primitives 1.2.0",
- "clap 4.5.36",
+ "alloy-primitives 1.2.1",
+ "clap 4.5.41",
  "derive_more 2.0.1",
  "serde",
  "strum 0.27.1",
@@ -12045,12 +12176,12 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.20",
+ "alloy-eips 1.0.20",
+ "alloy-primitives 1.2.1",
  "alloy-rpc-types-engine",
  "auto_impl",
  "reth-chainspec",
@@ -12069,11 +12200,11 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-eips 1.0.20",
+ "alloy-primitives 1.2.1",
  "alloy-rlp",
  "derive_more 2.0.1",
  "reth-primitives-traits",
@@ -12085,8 +12216,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tasks"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -12103,8 +12234,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -12113,10 +12244,10 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "clap 4.5.36",
+ "clap 4.5.41",
  "eyre",
  "rolling-file",
  "tracing",
@@ -12128,20 +12259,20 @@ dependencies = [
 
 [[package]]
 name = "reth-transaction-pool"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.20",
+ "alloy-eips 1.0.20",
+ "alloy-primitives 1.2.1",
  "alloy-rlp",
  "aquamarine",
  "auto_impl",
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "futures-util",
  "metrics",
  "parking_lot",
- "rand 0.9.0",
+ "rand 0.9.1",
  "reth-chain-state",
  "reth-chainspec",
  "reth-eth-wire-types",
@@ -12166,14 +12297,14 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.20",
+ "alloy-eips 1.0.20",
+ "alloy-primitives 1.2.1",
  "alloy-rlp",
- "alloy-trie 0.8.1",
+ "alloy-trie 0.9.0",
  "auto_impl",
  "itertools 0.14.0",
  "metrics",
@@ -12191,21 +12322,21 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.20",
+ "alloy-primitives 1.2.1",
  "alloy-rlp",
- "alloy-rpc-types-eth 1.0.9",
- "alloy-serde 1.0.9",
- "alloy-trie 0.8.1",
+ "alloy-rpc-types-eth 1.0.20",
+ "alloy-serde 1.0.20",
+ "alloy-trie 0.9.0",
  "arbitrary",
  "bytes",
  "derive_more 2.0.1",
  "hash-db",
  "itertools 0.14.0",
- "nybbles",
+ "nybbles 0.4.1",
  "plain_hasher",
  "rayon",
  "reth-codecs",
@@ -12217,10 +12348,10 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-db"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.2.1",
  "reth-db-api",
  "reth-execution-errors",
  "reth-primitives-traits",
@@ -12230,10 +12361,10 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-parallel"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.2.1",
  "alloy-rlp",
  "derive_more 2.0.1",
  "itertools 0.14.0",
@@ -12255,12 +12386,12 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.2.1",
  "alloy-rlp",
- "alloy-trie 0.8.1",
+ "alloy-trie 0.9.0",
  "auto_impl",
  "metrics",
  "reth-execution-errors",
@@ -12273,17 +12404,16 @@ dependencies = [
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.5.0"
+source = "git+https://github.com/bharath-123/reth?branch=bharath%2Ffusaka-revm-fix#95f0cf979d3b13b26a98ece83c4540e715210eb7"
 dependencies = [
  "zstd 0.13.3",
 ]
 
 [[package]]
 name = "revm"
-version = "24.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d277408ff8d6f747665ad9e52150ab4caf8d5eaf0d787614cf84633c8337b4"
+version = "27.0.2"
+source = "git+https://github.com/bluealloy/revm?branch=rakita%2Feip7907#37edc381a940a52abb90b3e0a480292a675e8129"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -12300,9 +12430,8 @@ dependencies = [
 
 [[package]]
 name = "revm-bytecode"
-version = "4.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91f9b90b3bab18942252de2d970ee8559794c49ca7452b2cc1774456040f8fb"
+version = "6.0.1"
+source = "git+https://github.com/bluealloy/revm?branch=rakita%2Feip7907#37edc381a940a52abb90b3e0a480292a675e8129"
 dependencies = [
  "bitvec",
  "once_cell",
@@ -12313,9 +12442,8 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "5.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b01aad49e1233f94cebda48a4e5cef022f7c7ed29b4edf0d202b081af23435ef"
+version = "8.0.2"
+source = "git+https://github.com/bluealloy/revm?branch=rakita%2Feip7907#37edc381a940a52abb90b3e0a480292a675e8129"
 dependencies = [
  "cfg-if",
  "derive-where",
@@ -12329,9 +12457,8 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b844f48a411e62c7dde0f757bf5cce49c85b86d6fc1d3b2722c07f2bec4c3ce"
+version = "8.0.1"
+source = "git+https://github.com/bluealloy/revm?branch=rakita%2Feip7907#37edc381a940a52abb90b3e0a480292a675e8129"
 dependencies = [
  "alloy-eip2930 0.2.1",
  "alloy-eip7702 0.6.1",
@@ -12345,11 +12472,10 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "4.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad3fbe34f6bb00a9c3155723b3718b9cb9f17066ba38f9eb101b678cd3626775"
+version = "7.0.1"
+source = "git+https://github.com/bluealloy/revm?branch=rakita%2Feip7907#37edc381a940a52abb90b3e0a480292a675e8129"
 dependencies = [
- "alloy-eips 1.0.9",
+ "alloy-eips 1.0.20",
  "revm-bytecode",
  "revm-database-interface",
  "revm-primitives",
@@ -12359,11 +12485,11 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "4.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b8acd36784a6d95d5b9e1b7be3ce014f1e759abb59df1fa08396b30f71adc2a"
+version = "7.0.1"
+source = "git+https://github.com/bluealloy/revm?branch=rakita%2Feip7907#37edc381a940a52abb90b3e0a480292a675e8129"
 dependencies = [
  "auto_impl",
+ "either",
  "revm-primitives",
  "revm-state",
  "serde",
@@ -12371,11 +12497,11 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "5.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "481e8c3290ff4fa1c066592fdfeb2b172edfd14d12e6cade6f6f5588cad9359a"
+version = "8.0.2"
+source = "git+https://github.com/bluealloy/revm?branch=rakita%2Feip7907#37edc381a940a52abb90b3e0a480292a675e8129"
 dependencies = [
  "auto_impl",
+ "derive-where",
  "revm-bytecode",
  "revm-context",
  "revm-context-interface",
@@ -12389,11 +12515,11 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "5.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc1167ef8937d8867888e63581d8ece729a72073d322119ef4627d813d99ecb"
+version = "8.0.2"
+source = "git+https://github.com/bluealloy/revm?branch=rakita%2Feip7907#37edc381a940a52abb90b3e0a480292a675e8129"
 dependencies = [
  "auto_impl",
+ "either",
  "revm-context",
  "revm-database-interface",
  "revm-handler",
@@ -12406,14 +12532,14 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.23.0"
+version = "0.26.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b50ef375dbacefecfdacf8f02afc31df98acc5d8859a6f2b24d121ff2a740a8"
+checksum = "c7b99a2332cf8eed9e9a22fffbf76dfadc99d2c45de6ae6431a1eb9f657dd97a"
 dependencies = [
- "alloy-primitives 1.2.0",
- "alloy-rpc-types-eth 1.0.9",
+ "alloy-primitives 1.2.1",
+ "alloy-rpc-types-eth 1.0.20",
  "alloy-rpc-types-trace",
- "alloy-sol-types 1.2.0",
+ "alloy-sol-types 1.2.1",
  "anstyle",
  "boa_engine",
  "boa_gc",
@@ -12426,9 +12552,8 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "20.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5ee65e57375c6639b0f50555e92a4f1b2434349dd32f52e2176f5c711171697"
+version = "23.0.1"
+source = "git+https://github.com/bluealloy/revm?branch=rakita%2Feip7907#37edc381a940a52abb90b3e0a480292a675e8129"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -12438,15 +12563,15 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "21.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9311e735123d8d53a02af2aa81877bba185be7c141be7f931bb3d2f3af449c"
+version = "24.0.0"
+source = "git+https://github.com/bluealloy/revm?branch=rakita%2Feip7907#37edc381a940a52abb90b3e0a480292a675e8129"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
  "ark-ec",
  "ark-ff 0.5.0",
  "ark-serialize 0.5.0",
+ "arrayref",
  "aurora-engine-modexp",
  "blst",
  "c-kzg",
@@ -12457,28 +12582,27 @@ dependencies = [
  "p256",
  "revm-primitives",
  "ripemd",
- "secp256k1",
- "sha2 0.10.8",
+ "rug",
+ "secp256k1 0.31.1",
+ "sha2 0.10.9",
 ]
 
 [[package]]
 name = "revm-primitives"
-version = "19.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18ea2ea0134568ee1e14281ce52f60e2710d42be316888d464c53e37ff184fd8"
+version = "20.0.0"
+source = "git+https://github.com/bluealloy/revm?branch=rakita%2Feip7907#37edc381a940a52abb90b3e0a480292a675e8129"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.2.1",
  "num_enum",
  "serde",
 ]
 
 [[package]]
 name = "revm-state"
-version = "4.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0040c61c30319254b34507383ba33d85f92949933adf6525a2cede05d165e1fa"
+version = "7.0.1"
+source = "git+https://github.com/bluealloy/revm?branch=rakita%2Feip7907#37edc381a940a52abb90b3e0a480292a675e8129"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "revm-bytecode",
  "revm-primitives",
  "serde",
@@ -12491,7 +12615,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
 dependencies = [
  "crypto-bigint 0.4.9",
- "hmac 0.12.1",
+ "hmac",
  "zeroize",
 ]
 
@@ -12501,7 +12625,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac 0.12.1",
+ "hmac",
  "subtle",
 ]
 
@@ -12528,7 +12652,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "libc",
  "untrusted 0.9.0",
  "windows-sys 0.52.0",
@@ -12648,10 +12772,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "ruint"
-version = "1.14.0"
+name = "rug"
+version = "1.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78a46eb779843b2c4f21fac5773e25d6d5b7c8f0922876c91541790d2ca27eef"
+checksum = "4207e8d668e5b8eb574bda8322088ccd0d7782d3d03c7e8d562e82ed82bdcbc3"
+dependencies = [
+ "az",
+ "gmp-mpfr-sys",
+ "libc",
+ "libm",
+]
+
+[[package]]
+name = "ruint"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11256b5fe8c68f56ac6f39ef0720e592f33d2367a4782740d9c9142e889c7fb4"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -12667,7 +12803,7 @@ dependencies = [
  "primitive-types",
  "proptest",
  "rand 0.8.5",
- "rand 0.9.0",
+ "rand 0.9.1",
  "rlp",
  "ruint-macro",
  "serde",
@@ -12718,9 +12854,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
 
 [[package]]
 name = "rustc-hash"
@@ -12767,7 +12903,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -12776,11 +12912,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.5"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
@@ -12801,15 +12937,15 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.26"
+version = "0.23.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df51b5869f3a441595eac5e8ff14d486ff285f7b8c0df8770e49c3b56351f0f0"
+checksum = "2491382039b29b9b11ff08b76ff6c97cf287671dbb74f0be44bda389fffe9bd1"
 dependencies = [
  "log",
  "once_cell",
  "ring 0.17.14",
  "rustls-pki-types",
- "rustls-webpki 0.103.1",
+ "rustls-webpki 0.103.4",
  "subtle",
  "zeroize",
 ]
@@ -12821,7 +12957,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile 1.0.4",
+ "rustls-pemfile",
  "schannel",
  "security-framework 2.11.1",
 ]
@@ -12848,41 +12984,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "rustls-pki-types"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
  "web-time",
+ "zeroize",
 ]
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.5.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5467026f437b4cb2a533865eaa73eb840019a0916f4b9ec563c6e617e086c9"
+checksum = "19787cda76408ec5404443dc8b31795c87cd8fec49762dc75fa727740d34acc1"
 dependencies = [
- "core-foundation 0.10.0",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.26",
+ "rustls 0.23.29",
  "rustls-native-certs 0.8.1",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.1",
+ "rustls-webpki 0.103.4",
  "security-framework 3.2.0",
  "security-framework-sys",
- "webpki-root-certs",
+ "webpki-root-certs 0.26.11",
  "windows-sys 0.59.0",
 ]
 
@@ -12904,9 +13032,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.1"
+version = "0.103.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fef8b8769aaccf73098557a87cd1816b4f9c7c16811c9c77142aa695c16f2c03"
+checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
 dependencies = [
  "ring 0.17.14",
  "rustls-pki-types",
@@ -12915,9 +13043,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "rusty-fork"
@@ -12982,7 +13110,7 @@ dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -12992,6 +13120,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
 dependencies = [
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -13040,10 +13192,10 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f9e24d2b632954ded8ab2ef9fea0a0c769ea56ea98bddbafbad22caeeadf45d"
 dependencies = [
- "hmac 0.12.1",
+ "hmac",
  "pbkdf2 0.11.0",
  "salsa20",
- "sha2 0.10.8",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -13077,7 +13229,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct 0.2.0",
- "der 0.7.9",
+ "der 0.7.10",
  "generic-array",
  "pkcs8 0.10.2",
  "serdect",
@@ -13093,8 +13245,19 @@ checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
 dependencies = [
  "bitcoin_hashes",
  "rand 0.8.5",
- "secp256k1-sys",
+ "secp256k1-sys 0.10.1",
  "serde",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c3c81b43dc2d8877c216a3fccf76677ee1ebccd429566d3e67447290d0c42b2"
+dependencies = [
+ "bitcoin_hashes",
+ "rand 0.9.1",
+ "secp256k1-sys 0.11.0",
 ]
 
 [[package]]
@@ -13107,12 +13270,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "secp256k1-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb913707158fadaf0d8702c2db0e857de66eb003ccfdda5924b5f5ac98efb38"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -13125,8 +13297,8 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
 dependencies = [
- "bitflags 2.9.0",
- "core-foundation 0.10.0",
+ "bitflags 2.9.1",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -13148,9 +13320,9 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4eb30575f3638fc8f6815f448d50cb1a2e255b0897985c8c59f4d37b72a07b06"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "cssparser",
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
  "fxhash",
  "log",
  "new_debug_unreachable",
@@ -13223,7 +13395,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -13232,7 +13404,7 @@ version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "itoa",
  "memchr",
  "ryu",
@@ -13252,9 +13424,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
 ]
@@ -13273,15 +13445,17 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.12.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6b6f7f2fcb69f747921f79f3926bd1e203fce4fef62c268dd3abfb6d86029aa"
+checksum = "f2c45cd61fefa9db6f254525d46e392b852e0e61d9a1fd36e5bd183450a556d5"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
+ "schemars 0.9.0",
+ "schemars 1.0.4",
  "serde",
  "serde_derive",
  "serde_json",
@@ -13291,14 +13465,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.12.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d00caa5193a3c8362ac2b73be6b9e768aa5a4b2f721d8f4b339600c3cb51f8e"
+checksum = "de90945e6565ce0d9a25098082ed4ee4002e047cb59892c318d66821e14bb30f"
 dependencies = [
  "darling 0.20.11",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -13377,9 +13551,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -13432,9 +13606,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -13453,9 +13627,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.2"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
 dependencies = [
  "libc",
 ]
@@ -13554,18 +13728,15 @@ checksum = "c1e9a774a6c28142ac54bb25d25562e6bcf957493a184f15ad4eebccb23e410a"
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg 1.4.0",
-]
+checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
 
 [[package]]
 name = "smallvec"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
  "arbitrary",
  "serde",
@@ -13577,7 +13748,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fb72c633efbaa2dd666986505016c32c3044395ceaf881518399d2f4127ee29"
 dependencies = [
- "autocfg 1.4.0",
+ "autocfg 1.5.0",
  "static_assertions",
  "version_check 0.9.5",
 ]
@@ -13590,9 +13761,9 @@ checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
 name = "socket2"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -13685,7 +13856,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der 0.7.9",
+ "der 0.7.10",
 ]
 
 [[package]]
@@ -13749,7 +13920,7 @@ dependencies = [
  "futures-util",
  "hashlink 0.8.4",
  "hex",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "log",
  "memchr",
  "native-tls",
@@ -13758,7 +13929,7 @@ dependencies = [
  "percent-encoding",
  "serde",
  "serde_json",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "smallvec",
  "sqlformat",
  "thiserror 1.0.69",
@@ -13767,7 +13938,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "url",
- "uuid 1.16.0",
+ "uuid 1.17.0",
 ]
 
 [[package]]
@@ -13798,7 +13969,7 @@ dependencies = [
  "quote 1.0.40",
  "serde",
  "serde_json",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "sqlx-core",
  "sqlx-mysql",
  "sqlx-postgres",
@@ -13818,7 +13989,7 @@ dependencies = [
  "atoi",
  "base64 0.21.7",
  "bigdecimal 0.3.1",
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "byteorder",
  "bytes",
  "chrono",
@@ -13833,7 +14004,7 @@ dependencies = [
  "generic-array",
  "hex",
  "hkdf",
- "hmac 0.12.1",
+ "hmac",
  "itoa",
  "log",
  "md-5",
@@ -13844,14 +14015,14 @@ dependencies = [
  "rsa",
  "serde",
  "sha1",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
  "thiserror 1.0.69",
  "time",
  "tracing",
- "uuid 1.16.0",
+ "uuid 1.17.0",
  "whoami",
 ]
 
@@ -13864,7 +14035,7 @@ dependencies = [
  "atoi",
  "base64 0.21.7",
  "bigdecimal 0.3.1",
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "byteorder",
  "chrono",
  "crc",
@@ -13876,7 +14047,7 @@ dependencies = [
  "futures-util",
  "hex",
  "hkdf",
- "hmac 0.12.1",
+ "hmac",
  "home",
  "itoa",
  "log",
@@ -13887,14 +14058,14 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
  "thiserror 1.0.69",
  "time",
  "tracing",
- "uuid 1.16.0",
+ "uuid 1.17.0",
  "whoami",
 ]
 
@@ -13921,7 +14092,7 @@ dependencies = [
  "tracing",
  "url",
  "urlencoding",
- "uuid 1.16.0",
+ "uuid 1.17.0",
 ]
 
 [[package]]
@@ -14072,7 +14243,7 @@ dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
  "rustversion",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -14085,7 +14256,7 @@ dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
  "rustversion",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -14098,7 +14269,7 @@ dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
  "rustversion",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -14121,7 +14292,7 @@ dependencies = [
  "semver 1.0.26",
  "serde",
  "serde_json",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "url",
  "zip",
@@ -14151,9 +14322,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
@@ -14169,19 +14340,19 @@ dependencies = [
  "paste",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "syn-solidity"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c8c8f496c33dc6343dac05b4be8d9e0bca180a4caa81d7b8416b10cc2273cd"
+checksum = "b9ac494e7266fcdd2ad80bf4375d55d27a117ea5c866c26d0e97fe5b3caeeb75"
 dependencies = [
  "paste",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -14213,13 +14384,13 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -14254,7 +14425,7 @@ dependencies = [
 name = "sysperf"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.2.1",
  "num_cpus",
  "rand 0.8.5",
  "rayon",
@@ -14278,7 +14449,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "core-foundation 0.9.4",
  "system-configuration-sys 0.6.0",
 ]
@@ -14339,9 +14510,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
  "fastrand 2.3.0",
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
  "once_cell",
- "rustix 1.0.5",
+ "rustix 1.0.7",
  "windows-sys 0.59.0",
 ]
 
@@ -14387,11 +14558,11 @@ name = "test-relay"
 version = "0.1.0"
 dependencies = [
  "ahash",
- "alloy-consensus 1.0.9",
- "alloy-json-rpc 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.20",
+ "alloy-json-rpc 1.0.20",
+ "alloy-primitives 1.2.1",
  "alloy-provider",
- "clap 4.5.36",
+ "clap 4.5.41",
  "clap_builder",
  "ctor",
  "ethereum_ssz 0.9.0",
@@ -14421,7 +14592,7 @@ dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
  "reqwest 0.11.27",
- "syn 2.0.100",
+ "syn 2.0.104",
  "which",
 ]
 
@@ -14463,7 +14634,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -14474,17 +14645,16 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
- "once_cell",
 ]
 
 [[package]]
@@ -14577,7 +14747,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
 dependencies = [
  "displaydoc",
- "zerovec",
+ "zerovec 0.10.4",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
+dependencies = [
+ "displaydoc",
+ "zerovec 0.11.2",
 ]
 
 [[package]]
@@ -14607,17 +14787,19 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.44.2"
+version = "1.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
+checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
  "libc",
  "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
+ "slab",
  "socket2",
  "tokio-macros",
  "windows-sys 0.52.0",
@@ -14631,7 +14813,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -14660,7 +14842,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
- "rustls 0.23.26",
+ "rustls 0.23.29",
  "tokio",
 ]
 
@@ -14726,19 +14908,19 @@ checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.23.26",
+ "rustls 0.23.29",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.2",
  "tungstenite 0.26.2",
- "webpki-roots 0.26.8",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
 name = "tokio-util"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9590b93e6fcc1739458317cccd391ad3955e2bde8913edf6f95f9e65a8f034"
+checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
 dependencies = [
  "bytes",
  "futures-core",
@@ -14760,9 +14942,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.20"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -14772,25 +14954,32 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.24"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
+ "toml_write",
  "winnow",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -14816,7 +15005,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "hdrhistogram",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "pin-project-lite",
  "slab",
  "sync_wrapper 1.0.2",
@@ -14829,13 +15018,13 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.2"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403fa3b783d4b626a8ad51d766ab03cb6d2dbfc46b1c5d4448395e6628dc9697"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
  "async-compression",
  "base64 0.22.1",
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -14855,7 +15044,7 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
- "uuid 1.16.0",
+ "uuid 1.17.0",
 ]
 
 [[package]]
@@ -14896,20 +15085,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.28"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
  "valuable",
@@ -15018,7 +15207,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee44f4cef85f88b4dea21c0b1f58320bdf35715cf56d840969487cff00613321"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.2.1",
  "ethereum_hashing 0.7.0",
  "ethereum_ssz 0.9.0",
  "smallvec",
@@ -15034,7 +15223,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -15130,8 +15319,8 @@ dependencies = [
  "http 1.3.1",
  "httparse",
  "log",
- "rand 0.9.0",
- "rustls 0.23.26",
+ "rand 0.9.1",
+ "rustls 0.23.29",
  "rustls-pki-types",
  "sha1",
  "thiserror 2.0.12",
@@ -15140,13 +15329,9 @@ dependencies = [
 
 [[package]]
 name = "twox-hash"
-version = "1.6.3"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
-dependencies = [
- "cfg-if",
- "static_assertions",
-]
+checksum = "8b907da542cbced5261bd3256de1b3a1bf340a3d37f93425a07362a1d687de56"
 
 [[package]]
 name = "typenum"
@@ -15314,10 +15499,10 @@ dependencies = [
  "flate2",
  "log",
  "once_cell",
- "rustls 0.23.26",
+ "rustls 0.23.29",
  "rustls-pki-types",
  "url",
- "webpki-roots 0.26.8",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -15368,19 +15553,21 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "serde",
 ]
 
 [[package]]
 name = "uuid"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 dependencies = [
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
+ "js-sys",
  "serde",
  "sha1_smol",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -15456,7 +15643,7 @@ checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -15530,9 +15717,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
@@ -15571,7 +15758,7 @@ dependencies = [
  "log",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
  "wasm-bindgen-shared",
 ]
 
@@ -15606,7 +15793,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -15635,9 +15822,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtimer"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0048ad49a55b9deb3953841fa1fc5858f0efbcb7a18868c899a360269fac1b23"
+checksum = "d8d49b5d6c64e8558d9b1b065014426f35c18de636895d24893dbbd329743446"
 dependencies = [
  "futures",
  "js-sys",
@@ -15679,9 +15866,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "0.26.8"
+version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09aed61f5e8d2c18344b3faa33a4c837855fe56642757754775548fee21386c4"
+checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
+dependencies = [
+ "webpki-root-certs 1.0.1",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86138b15b2b7d561bc4469e77027b8dd005a43dc502e9031d1f5afc8ce1f280e"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -15694,9 +15890,18 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.8"
+version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.1",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8782dd5a41a24eed3a4f40b606249b3e236ca61adf1f25ea4d45c73de122b502"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -15781,6 +15986,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections",
+ "windows-core 0.61.2",
+ "windows-future",
+ "windows-link",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.2",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15807,15 +16034,26 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.61.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement 0.60.0",
  "windows-interface 0.59.1",
  "windows-link",
- "windows-result 0.3.2",
- "windows-strings 0.4.0",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -15826,7 +16064,7 @@ checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -15837,7 +16075,7 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -15848,7 +16086,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -15859,7 +16097,7 @@ checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -15870,7 +16108,7 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -15881,24 +16119,34 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "windows-link"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-registry"
-version = "0.4.0"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
 dependencies = [
- "windows-result 0.3.2",
- "windows-strings 0.3.1",
- "windows-targets 0.53.0",
+ "windows-link",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]
@@ -15921,9 +16169,9 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
  "windows-link",
 ]
@@ -15940,18 +16188,9 @@ dependencies = [
 
 [[package]]
 name = "windows-strings"
-version = "0.3.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link",
 ]
@@ -15990,6 +16229,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.2",
 ]
 
 [[package]]
@@ -16040,9 +16288,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.0"
+version = "0.53.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
 dependencies = [
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
@@ -16052,6 +16300,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.0",
  "windows_x86_64_gnullvm 0.53.0",
  "windows_x86_64_msvc 0.53.0",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -16236,9 +16493,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.6"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63d3fcd9bba44b03821e7d699eeee959f3126dcc4aa8e4ae18ec617c2a5cea10"
+checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
 dependencies = [
  "memchr",
 ]
@@ -16259,7 +16516,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -16275,10 +16532,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
-name = "ws_stream_wasm"
-version = "0.7.4"
+name = "writeable"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7999f5f4217fe3818726b66257a4475f71e74ffd190776ad053fa159e50737f5"
+checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
+name = "ws_stream_wasm"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c173014acad22e83f16403ee360115b38846fe754e735c5d9d3803fe70c6abc"
 dependencies = [
  "async_io_stream",
  "futures",
@@ -16287,7 +16550,7 @@ dependencies = [
  "pharos",
  "rustc_version 0.4.1",
  "send_wrapper 0.6.0",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -16304,12 +16567,12 @@ dependencies = [
 
 [[package]]
 name = "xattr"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d65cbf2f12c15564212d48f4e3dfb87923d25d611f2aed18f4cb23f0413d89e"
+checksum = "af3a19837351dc82ba89f8a125e22a3c475f05aba604acc023d62b2739ae2909"
 dependencies = [
  "libc",
- "rustix 1.0.5",
+ "rustix 1.0.7",
 ]
 
 [[package]]
@@ -16347,7 +16610,19 @@ checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
 dependencies = [
  "serde",
  "stable_deref_trait",
- "yoke-derive",
+ "yoke-derive 0.7.5",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive 0.8.0",
  "zerofrom",
 ]
 
@@ -16359,48 +16634,40 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
- "synstructure 0.13.1",
+ "syn 2.0.104",
+ "synstructure 0.13.2",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
+dependencies = [
+ "proc-macro2 1.0.95",
+ "quote 1.0.40",
+ "syn 2.0.104",
+ "synstructure 0.13.2",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
 dependencies = [
- "zerocopy-derive 0.7.35",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
-dependencies = [
- "zerocopy-derive 0.8.24",
+ "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.35"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
-dependencies = [
- "proc-macro2 1.0.95",
- "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -16420,8 +16687,8 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
- "synstructure 0.13.1",
+ "syn 2.0.104",
+ "synstructure 0.13.2",
 ]
 
 [[package]]
@@ -16441,7 +16708,18 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+dependencies = [
+ "displaydoc",
+ "yoke 0.8.0",
+ "zerofrom",
 ]
 
 [[package]]
@@ -16450,9 +16728,20 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
 dependencies = [
- "yoke",
+ "yoke 0.7.5",
  "zerofrom",
- "zerovec-derive",
+ "zerovec-derive 0.10.3",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
+dependencies = [
+ "yoke 0.8.0",
+ "zerofrom",
+ "zerovec-derive 0.11.1",
 ]
 
 [[package]]
@@ -16463,7 +16752,18 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.100",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
+dependencies = [
+ "proc-macro2 1.0.95",
+ "quote 1.0.40",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -16479,7 +16779,7 @@ dependencies = [
  "crc32fast",
  "crossbeam-utils",
  "flate2",
- "hmac 0.12.1",
+ "hmac",
  "pbkdf2 0.11.0",
  "sha1",
  "time",
@@ -16551,3 +16851,8 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[patch.unused]]
+name = "alloy-contract"
+version = "1.0.20"
+source = "git+https://github.com/alloy-rs/alloy?branch=fusaka%2Fdevnet2#000b830535a0b4d6374bc09727e3663fb6af9b89"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1115,7 +1115,7 @@ dependencies = [
  "alloy-transport",
  "futures",
  "http 1.3.1",
- "rustls 0.23.29",
+ "rustls 0.23.30",
  "serde_json",
  "tokio",
  "tokio-tungstenite 0.26.2",
@@ -3740,9 +3740,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ecdsa"
@@ -5697,7 +5697,7 @@ dependencies = [
  "hyper 1.6.0",
  "hyper-util",
  "log",
- "rustls 0.23.29",
+ "rustls 0.23.30",
  "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
@@ -6440,7 +6440,7 @@ dependencies = [
  "http 1.3.1",
  "jsonrpsee-core 0.25.1",
  "pin-project",
- "rustls 0.23.29",
+ "rustls 0.23.30",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "soketto 0.8.1",
@@ -6539,7 +6539,7 @@ dependencies = [
  "hyper-util",
  "jsonrpsee-core 0.25.1",
  "jsonrpsee-types 0.25.1",
- "rustls 0.23.29",
+ "rustls 0.23.30",
  "rustls-platform-verifier",
  "serde",
  "serde_json",
@@ -8855,9 +8855,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.35"
+version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061c1221631e079b26479d25bbf2275bfe5917ae8419cd7e34f13bfc2aa7539a"
+checksum = "ff24dfcda44452b9816fff4cd4227e1bb73ff5a2f1bc1105aa92fb8565ce44d2"
 dependencies = [
  "proc-macro2 1.0.95",
  "syn 2.0.104",
@@ -9110,9 +9110,9 @@ dependencies = [
 
 [[package]]
 name = "quick_cache"
-version = "0.6.14"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b450dad8382b1b95061d5ca1eb792081fb082adf48c678791fe917509596d5f"
+checksum = "8565e62e02af316570d4b492f17af1481d6c07cea60f4e7edd71700da5052ba9"
 dependencies = [
  "ahash",
  "equivalent",
@@ -9132,7 +9132,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.1",
- "rustls 0.23.29",
+ "rustls 0.23.30",
  "socket2 0.5.10",
  "thiserror 2.0.12",
  "tokio",
@@ -9152,7 +9152,7 @@ dependencies = [
  "rand 0.9.2",
  "ring 0.17.14",
  "rustc-hash 2.1.1",
- "rustls 0.23.29",
+ "rustls 0.23.30",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.12",
@@ -9616,9 +9616,9 @@ checksum = "d3edd4d5d42c92f0a659926464d4cce56b562761267ecf0f469d85b7de384175"
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.15"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8af0dde094006011e6a740d4879319439489813bd0bcdc7d821beaeeff48ec"
+checksum = "7251471db004e509f4e75a62cca9435365b5ec7bcdff530d612ac7c87c44a792"
 dependencies = [
  "bitflags 2.9.1",
 ]
@@ -9809,7 +9809,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.29",
+ "rustls 0.23.30",
  "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "serde",
@@ -12872,9 +12872,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustc-hash"
@@ -12955,9 +12955,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.29"
+version = "0.23.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2491382039b29b9b11ff08b76ff6c97cf287671dbb74f0be44bda389fffe9bd1"
+checksum = "069a8df149a16b1a12dcc31497c3396a173844be3cac4bd40c9e7671fef96671"
 dependencies = [
  "log",
  "once_cell",
@@ -13022,7 +13022,7 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.29",
+ "rustls 0.23.30",
  "rustls-native-certs 0.8.1",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.103.4",
@@ -14793,9 +14793,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.46.1"
+version = "1.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
+checksum = "43864ed400b6043a4757a25c7a64a8efde741aed79a056a2fb348a406701bb35"
 dependencies = [
  "backtrace",
  "bytes",
@@ -14806,9 +14806,9 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "slab",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "tokio-macros",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -14848,7 +14848,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
- "rustls 0.23.29",
+ "rustls 0.23.30",
  "tokio",
 ]
 
@@ -14914,7 +14914,7 @@ checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.23.29",
+ "rustls 0.23.30",
  "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
@@ -15325,7 +15325,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.2",
- "rustls 0.23.29",
+ "rustls 0.23.30",
  "rustls-pki-types",
  "sha1",
  "thiserror 2.0.12",
@@ -15504,7 +15504,7 @@ dependencies = [
  "flate2",
  "log",
  "once_cell",
- "rustls 0.23.29",
+ "rustls 0.23.30",
  "rustls-pki-types",
  "url",
  "webpki-roots 0.26.11",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3681,7 +3681,7 @@ dependencies = [
  "parking_lot",
  "rand 0.8.5",
  "smallvec",
- "socket2",
+ "socket2 0.5.10",
  "tokio",
  "tracing",
  "uint 0.10.0",
@@ -5643,7 +5643,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -5737,9 +5737,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66d5bd4c6f02bf0542fad85d626775bab9258cf795a4256dcaf3161114d1df"
+checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -5753,7 +5753,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.0",
  "system-configuration 0.6.1",
  "tokio",
  "tower-service",
@@ -6245,7 +6245,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
 dependencies = [
- "socket2",
+ "socket2 0.5.10",
  "widestring",
  "windows-sys 0.48.0",
  "winreg",
@@ -9133,7 +9133,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.29",
- "socket2",
+ "socket2 0.5.10",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -9170,7 +9170,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -13767,6 +13767,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "soketto"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14796,7 +14806,7 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "slab",
- "socket2",
+ "socket2 0.5.10",
  "tokio-macros",
  "windows-sys 0.52.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,51 +49,51 @@ codegen-units = 1
 incremental = false
 
 [workspace.dependencies]
-reth = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
-reth-chain-state = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
-reth-cli-util = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
-reth-db = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
-reth-db-common = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
-reth-errors = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
-reth-payload-builder = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
-reth-node-api = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
-reth-node-ethereum = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
-reth-trie = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
-reth-trie-parallel = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
-reth-basic-payload-builder = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
-reth-node-core = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
-reth-primitives = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
-reth-ethereum-primitives = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
-reth-primitives-traits = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
-reth-provider = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix", features = [
+reth = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka-devnet-3" }
+reth-chain-state = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka-devnet-3" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka-devnet-3" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka-devnet-3" }
+reth-db-common = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka-devnet-3" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka-devnet-3" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka-devnet-3" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka-devnet-3" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka-devnet-3" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka-devnet-3" }
+reth-trie-parallel = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka-devnet-3" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka-devnet-3" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka-devnet-3" }
+reth-primitives = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka-devnet-3" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka-devnet-3" }
+reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka-devnet-3" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka-devnet-3", features = [
     "test-utils",
 ] }
-reth-chainspec = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
-reth-evm = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
-reth-evm-ethereum = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
-reth-execution-errors = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
-reth-exex = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
-reth-metrics = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
-reth-trie-db = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
-reth-payload-primitives = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
-reth-transaction-pool = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
-reth-execution-types = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
-reth-revm = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
-reth-payload-builder-primitives = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
-reth-payload-util = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
-reth-rpc-layer = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
-reth-testing-utils = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka-devnet-3" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka-devnet-3" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka-devnet-3" }
+reth-execution-errors = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka-devnet-3" }
+reth-exex = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka-devnet-3" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka-devnet-3" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka-devnet-3" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka-devnet-3" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka-devnet-3" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka-devnet-3" }
+reth-revm = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka-devnet-3" }
+reth-payload-builder-primitives = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka-devnet-3" }
+reth-payload-util = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka-devnet-3" }
+reth-rpc-layer = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka-devnet-3" }
+reth-testing-utils = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka-devnet-3" }
 
 # reth optimism
-reth-optimism-primitives = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
-reth-optimism-consensus = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
-reth-optimism-cli = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
-reth-optimism-forks = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
-reth-optimism-evm = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
-reth-optimism-node = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
-reth-optimism-payload-builder = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
-reth-optimism-chainspec = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
-reth-optimism-txpool = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-optimism-primitives = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka-devnet-3" }
+reth-optimism-consensus = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka-devnet-3" }
+reth-optimism-cli = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka-devnet-3" }
+reth-optimism-forks = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka-devnet-3" }
+reth-optimism-evm = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka-devnet-3" }
+reth-optimism-node = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka-devnet-3" }
+reth-optimism-payload-builder = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka-devnet-3" }
+reth-optimism-chainspec = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka-devnet-3" }
+reth-optimism-txpool = { git = "https://github.com/paradigmxyz/reth", branch = "fusaka-devnet-3" }
 
 
 # compatible with reth v1.4.8 dependencies
@@ -112,7 +112,7 @@ ethereum_ssz = "0.9.0"
 alloy-primitives = { version = "1.2.0", default-features = false }
 alloy-rlp = "0.3.10"
 alloy-chains = "0.2.0"
-alloy-evm = { version = "0.13", default-features = false }
+alloy-evm = { version = "0.15", default-features = false }
 alloy-provider = { version = "1.0.16", features = ["ipc", "pubsub"] }
 alloy-pubsub = { version = "1.0.16" }
 alloy-eips = { version = "1.0.16" }
@@ -173,46 +173,46 @@ metrics_macros = { path = "crates/rbuilder/src/telemetry/metrics_macros"}
 
 
 [patch.crates-io]
-alloy-consensus = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-alloy-contract = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-alloy-eips = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-alloy-genesis = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-alloy-network = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-alloy-network-primitives = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-alloy-provider = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-alloy-pubsub = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-alloy-rpc-client = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-alloy-rpc-types-admin = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-alloy-rpc-types-anvil = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-alloy-rpc-types-beacon = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-alloy-rpc-types-debug = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-alloy-rpc-types-eth = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-alloy-rpc-types-mev = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-alloy-rpc-types-txpool = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-alloy-serde = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-alloy-signer = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-alloy-signer-local = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-alloy-transport = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-alloy-transport-http = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-alloy-transport-ipc = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
-alloy-transport-ws = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
+alloy-consensus = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka-devnet-3" }
+alloy-contract = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka-devnet-3" }
+alloy-eips = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka-devnet-3" }
+alloy-genesis = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka-devnet-3" }
+alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka-devnet-3" }
+alloy-network = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka-devnet-3" }
+alloy-network-primitives = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka-devnet-3" }
+alloy-provider = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka-devnet-3" }
+alloy-pubsub = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka-devnet-3" }
+alloy-rpc-client = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka-devnet-3" }
+alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka-devnet-3" }
+alloy-rpc-types-admin = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka-devnet-3" }
+alloy-rpc-types-anvil = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka-devnet-3" }
+alloy-rpc-types-beacon = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka-devnet-3" }
+alloy-rpc-types-debug = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka-devnet-3" }
+alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka-devnet-3" }
+alloy-rpc-types-eth = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka-devnet-3" }
+alloy-rpc-types-mev = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka-devnet-3" }
+alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka-devnet-3" }
+alloy-rpc-types-txpool = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka-devnet-3" }
+alloy-serde = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka-devnet-3" }
+alloy-signer = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka-devnet-3" }
+alloy-signer-local = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka-devnet-3" }
+alloy-transport = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka-devnet-3" }
+alloy-transport-http = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka-devnet-3" }
+alloy-transport-ipc = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka-devnet-3" }
+alloy-transport-ws = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka-devnet-3" }
 
-alloy-evm = { git = "https://github.com/alloy-rs/evm", branch = "fusaka/devnet2"}
+alloy-eip2124 = { git = "https://github.com/alloy-rs/eips", branch = "rkrasiuk/fork-hash-from-bytes-arr" }
 
-revm = { git = "https://github.com/bluealloy/revm", branch = "rakita/eip7907" }
-revm-bytecode = { git = "https://github.com/bluealloy/revm", branch = "rakita/eip7907" }
-revm-database = { git = "https://github.com/bluealloy/revm", branch = "rakita/eip7907" }
-revm-state = { git = "https://github.com/bluealloy/revm", branch = "rakita/eip7907" }
-revm-handler = { git = "https://github.com/bluealloy/revm", branch = "rakita/eip7907" }
-revm-primitives = { git = "https://github.com/bluealloy/revm", branch = "rakita/eip7907" }
-revm-interpreter = { git = "https://github.com/bluealloy/revm", branch = "rakita/eip7907" }
-revm-inspector = { git = "https://github.com/bluealloy/revm", branch = "rakita/eip7907" }
-revm-context = { git = "https://github.com/bluealloy/revm", branch = "rakita/eip7907" }
-revm-context-interface = { git = "https://github.com/bluealloy/revm", branch = "rakita/eip7907" }
-revm-database-interface = { git = "https://github.com/bluealloy/revm", branch = "rakita/eip7907" }
-revm-precompile = { git = "https://github.com/bluealloy/revm", branch = "rakita/eip7907" }
-op-revm = { git = "https://github.com/bluealloy/revm", branch = "rakita/eip7907" }
+revm = { git = "https://github.com/bluealloy/revm", branch = "fusaka-devnet-3" }
+revm-bytecode = { git = "https://github.com/bluealloy/revm", branch = "fusaka-devnet-3" }
+revm-database = { git = "https://github.com/bluealloy/revm", branch = "fusaka-devnet-3" }
+revm-state = { git = "https://github.com/bluealloy/revm", branch = "fusaka-devnet-3" }
+revm-handler = { git = "https://github.com/bluealloy/revm", branch = "fusaka-devnet-3" }
+revm-primitives = { git = "https://github.com/bluealloy/revm", branch = "fusaka-devnet-3" }
+revm-interpreter = { git = "https://github.com/bluealloy/revm", branch = "fusaka-devnet-3" }
+revm-inspector = { git = "https://github.com/bluealloy/revm", branch = "fusaka-devnet-3" }
+revm-context = { git = "https://github.com/bluealloy/revm", branch = "fusaka-devnet-3" }
+revm-context-interface = { git = "https://github.com/bluealloy/revm", branch = "fusaka-devnet-3" }
+revm-database-interface = { git = "https://github.com/bluealloy/revm", branch = "fusaka-devnet-3" }
+revm-precompile = { git = "https://github.com/bluealloy/revm", branch = "fusaka-devnet-3" }
+op-revm = { git = "https://github.com/bluealloy/revm", branch = "fusaka-devnet-3" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,94 +49,90 @@ codegen-units = 1
 incremental = false
 
 [workspace.dependencies]
-reth = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-chain-state = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-db-common = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-trie-parallel = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8", features = [
+reth = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-chain-state = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-cli-util = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-db = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-db-common = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-errors = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-payload-builder = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-node-api = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-node-ethereum = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-trie = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-trie-parallel = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-basic-payload-builder = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-node-core = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-primitives = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-ethereum-primitives = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-primitives-traits = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-provider = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix", features = [
     "test-utils",
 ] }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-execution-errors = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-exex = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-revm = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-payload-builder-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-payload-util = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-rpc-layer = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-testing-utils = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
+reth-chainspec = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-evm = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-evm-ethereum = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-execution-errors = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-exex = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-metrics = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-trie-db = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-payload-primitives = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-transaction-pool = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-execution-types = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-revm = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-payload-builder-primitives = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-payload-util = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-rpc-layer = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-testing-utils = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
 
 # reth optimism
-reth-optimism-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-optimism-consensus = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-optimism-cli = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-optimism-forks = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-optimism-evm = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-optimism-node = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-optimism-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-optimism-chainspec = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-optimism-txpool = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
+reth-optimism-primitives = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-optimism-consensus = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-optimism-cli = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-optimism-forks = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-optimism-evm = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-optimism-node = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-optimism-payload-builder = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-optimism-chainspec = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+reth-optimism-txpool = { git = "https://github.com/bharath-123/reth", branch = "bharath/fusaka-revm-fix" }
+
 
 # compatible with reth v1.4.8 dependencies
-revm = { version = "24.0.1", features = [
+revm = { version = "27.0.1", features = [
     "std",
     "secp256k1",
     "optional_balance_check",
 ], default-features = false }
-revm-inspectors = { version = "0.23.0", default-features = false }
-op-revm = { version = "5.0.0", default-features = false }
+revm-inspectors = { version = "0.26.5", default-features = false }
+revm-state = { version = "7.0.0", default-features = false }
+revm-inspector = { version = "8.0.1", default-features = false }
 
 ethereum_ssz_derive = "0.9.0"
 ethereum_ssz = "0.9.0"
 
-alloy-primitives = { version = "1.1.0", default-features = false }
+alloy-primitives = { version = "1.2.0", default-features = false }
 alloy-rlp = "0.3.10"
 alloy-chains = "0.2.0"
-alloy-evm = { version = "0.10", default-features = false }
-alloy-provider = { version = "1.0.9", features = ["ipc", "pubsub"] }
-alloy-pubsub = { version = "1.0.9" }
-alloy-eips = { version = "1.0.9" }
-alloy-rpc-types = { version = "1.0.9" }
-alloy-json-rpc = { version = "1.0.9" }
-alloy-transport-http = { version = "1.0.9" }
-alloy-network = { version = "1.0.9" }
-alloy-network-primitives = { version = "1.0.9" }
-alloy-transport = { version = "1.0.9" }
-alloy-node-bindings = { version = "1.0.9" }
-alloy-consensus = { version = "1.0.9", features = ["kzg"] }
-alloy-serde = { version = "1.0.9" }
-alloy-rpc-types-beacon = { version = "1.0.9", features = ["ssz"] }
-alloy-rpc-types-engine = { version = "1.0.9", features = ["ssz"] }
-alloy-rpc-types-eth = { version = "1.0.9" }
-alloy-signer-local = { version = "1.0.9" }
-alloy-rpc-client = { version = "1.0.9" }
-alloy-genesis = { version = "1.0.9" }
-alloy-trie = { version = "0.8.1" }
-
-# optimism
-alloy-op-evm = { version = "0.5.0", default-features = false }
-op-alloy-rpc-types = { version = "0.14.1", default-features = false }
-op-alloy-rpc-types-engine = { version = "0.14.1", default-features = false }
-op-alloy-rpc-jsonrpsee = { version = "0.14.1", default-features = false }
-op-alloy-network = { version = "0.14.1", default-features = false }
-op-alloy-consensus = { version = "0.14.1", default-features = false }
+alloy-evm = { version = "0.13", default-features = false }
+alloy-provider = { version = "1.0.16", features = ["ipc", "pubsub"] }
+alloy-pubsub = { version = "1.0.16" }
+alloy-eips = { version = "1.0.16" }
+alloy-rpc-types = { version = "1.0.16" }
+alloy-json-rpc = { version = "1.0.16"  }
+alloy-transport-http = { version = "1.0.16"  }
+alloy-network = { version = "1.0.16"  }
+alloy-network-primitives = { version = "1.0.16"  }
+alloy-transport = { version = "1.0.16" }
+alloy-node-bindings = { version = "1.0.16"  }
+alloy-consensus = { version = "1.0.16" , features = ["kzg"] }
+alloy-serde = { version = "1.0.16"  }
+alloy-rpc-types-beacon = { version = "1.0.16" , features = ["ssz"] }
+alloy-rpc-types-engine = { version = "1.0.16" , features = ["ssz"] }
+alloy-rpc-types-eth = { version = "1.0.16"  }
+alloy-signer-local = { version = "1.0.16"  }
+alloy-rpc-client = { version = "1.0.16" }
+alloy-genesis = { version = "1.0.16"  }
+alloy-trie = { version = "0.8.1", default-features = false }
+nybbles = { version = "0.3.3" }
 
 async-trait = { version = "0.1.83" }
 clap = { version = "4.4.3", features = ["derive", "env"] }
@@ -174,3 +170,49 @@ eth-sparse-mpt = { path = "crates/eth-sparse-mpt" }
 rbuilder = { path = "crates/rbuilder" }
 sysperf = { path = "crates/sysperf" }
 metrics_macros = { path = "crates/rbuilder/src/telemetry/metrics_macros"}
+
+
+[patch.crates-io]
+alloy-consensus = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
+alloy-contract = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
+alloy-eips = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
+alloy-genesis = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
+alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
+alloy-network = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
+alloy-network-primitives = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
+alloy-provider = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
+alloy-pubsub = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
+alloy-rpc-client = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
+alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
+alloy-rpc-types-admin = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
+alloy-rpc-types-anvil = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
+alloy-rpc-types-beacon = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
+alloy-rpc-types-debug = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
+alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
+alloy-rpc-types-eth = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
+alloy-rpc-types-mev = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
+alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
+alloy-rpc-types-txpool = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
+alloy-serde = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
+alloy-signer = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
+alloy-signer-local = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
+alloy-transport = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
+alloy-transport-http = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
+alloy-transport-ipc = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
+alloy-transport-ws = { git = "https://github.com/alloy-rs/alloy", branch = "fusaka/devnet2" }
+
+alloy-evm = { git = "https://github.com/alloy-rs/evm", branch = "fusaka/devnet2"}
+
+revm = { git = "https://github.com/bluealloy/revm", branch = "rakita/eip7907" }
+revm-bytecode = { git = "https://github.com/bluealloy/revm", branch = "rakita/eip7907" }
+revm-database = { git = "https://github.com/bluealloy/revm", branch = "rakita/eip7907" }
+revm-state = { git = "https://github.com/bluealloy/revm", branch = "rakita/eip7907" }
+revm-handler = { git = "https://github.com/bluealloy/revm", branch = "rakita/eip7907" }
+revm-primitives = { git = "https://github.com/bluealloy/revm", branch = "rakita/eip7907" }
+revm-interpreter = { git = "https://github.com/bluealloy/revm", branch = "rakita/eip7907" }
+revm-inspector = { git = "https://github.com/bluealloy/revm", branch = "rakita/eip7907" }
+revm-context = { git = "https://github.com/bluealloy/revm", branch = "rakita/eip7907" }
+revm-context-interface = { git = "https://github.com/bluealloy/revm", branch = "rakita/eip7907" }
+revm-database-interface = { git = "https://github.com/bluealloy/revm", branch = "rakita/eip7907" }
+revm-precompile = { git = "https://github.com/bluealloy/revm", branch = "rakita/eip7907" }
+op-revm = { git = "https://github.com/bluealloy/revm", branch = "rakita/eip7907" }

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ build: ## Build (debug version)
 	cargo build --features "$(FEATURES)"
 
 .PHONY: docker-image-rbuilder
-docker-image-rubilder: ## Build a rbuilder Docker image
+docker-image-rbuilder: ## Build a rbuilder Docker image
 	docker build --platform linux/amd64 --target rbuilder-runtime --build-arg FEATURES="$(FEATURES)"  . -t rbuilder
 
 .PHONY: docker-image-test-relay

--- a/crates/eth-sparse-mpt/Cargo.toml
+++ b/crates/eth-sparse-mpt/Cargo.toml
@@ -19,6 +19,8 @@ smallvec = "1.13.2"
 
 tracing.workspace = true
 
+nybbles.workspace = true
+
 # reth
 reth-errors.workspace = true
 reth-execution-errors.workspace = true

--- a/crates/eth-sparse-mpt/benches/trie_do_bench.rs
+++ b/crates/eth-sparse-mpt/benches/trie_do_bench.rs
@@ -7,7 +7,7 @@ use eth_sparse_mpt::{
     v1::sparse_mpt::{DiffTrie, FixedTrie},
     v2::trie::{proof_store::ProofStore, Trie},
 };
-use reth_trie::Nibbles;
+use nybbles::Nibbles;
 
 fn prepare_key_value_data(n: usize) -> (Vec<Bytes>, Vec<Bytes>) {
     let mut keys = Vec::with_capacity(n);

--- a/crates/eth-sparse-mpt/src/utils.rs
+++ b/crates/eth-sparse-mpt/src/utils.rs
@@ -2,10 +2,8 @@ use std::hash::{Hash, Hasher};
 
 use alloy_primitives::{keccak256, Bytes};
 use alloy_rlp::{length_of_length, BufMut, Encodable, Header, EMPTY_STRING_CODE};
-use alloy_trie::{
-    nodes::{ExtensionNodeRef, LeafNodeRef},
-    Nibbles,
-};
+use alloy_trie::nodes::{ExtensionNodeRef, LeafNodeRef};
+use nybbles::Nibbles;
 use reth_trie::RlpNode;
 use rustc_hash::{FxBuildHasher, FxHasher};
 
@@ -137,4 +135,19 @@ fn mismatch_chunks<const N: usize>(xs: &[u8], ys: &[u8]) -> usize {
     off + std::iter::zip(&xs[off..], &ys[off..])
         .take_while(|(x, y)| x == y)
         .count()
+}
+
+// rbuilder uses nybbles v3.3.0 and reth_trie uses nybbles v4.1.0. This is a temporary fix to convert between the two.
+// We can remove the below methods once rbuilder has been upgraded to nybbles v4.1.0.
+// nybbles v4.1.0 has a breaking change in the API which breaks a lot of parts of the eth sparse trie code.
+pub fn convert_reth_nybbles_to_nibbles(n: reth_trie::Nibbles) -> Nibbles {
+    let mut nibbles = Nibbles::new();
+    nibbles.extend_from_slice_unchecked(n.to_vec().as_slice());
+    nibbles
+}
+
+pub fn convert_nibbles_to_reth_nybbles(n: Nibbles) -> reth_trie::Nibbles {
+    let mut nibbles = reth_trie::Nibbles::new();
+    nibbles.extend_from_slice(n.pack().as_slice());
+    nibbles
 }

--- a/crates/eth-sparse-mpt/src/v1/reth_sparse_trie/shared_cache.rs
+++ b/crates/eth-sparse-mpt/src/v1/reth_sparse_trie/shared_cache.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use alloy_primitives::Bytes;
 use alloy_primitives::B256;
-use alloy_trie::Nibbles;
+use nybbles::Nibbles;
 
 /// SparseTrieSharedCache is a storage for fetched parts of the ethereum tries
 /// It should be created once for each parent block and can be shared with a different threads.

--- a/crates/eth-sparse-mpt/src/v1/reth_sparse_trie/trie_fetcher/mod.rs
+++ b/crates/eth-sparse-mpt/src/v1/reth_sparse_trie/trie_fetcher/mod.rs
@@ -1,11 +1,11 @@
 use std::time::Instant;
 
-use crate::utils::{hash_map_with_capacity, HashMap, HashSet};
+use crate::utils::{convert_reth_nybbles_to_nibbles, hash_map_with_capacity, HashMap, HashSet};
 use alloy_primitives::map::HashSet as AlloyHashSet;
 use tracing::trace;
 
 use alloy_primitives::{Bytes, B256};
-use alloy_trie::Nibbles;
+use nybbles::Nibbles;
 use rayon::prelude::*;
 use reth_errors::ProviderError;
 use reth_execution_errors::trie::StateProofError;
@@ -194,7 +194,7 @@ fn convert_reth_multiproof(
 ) -> MultiProof {
     let mut account_subtree = Vec::with_capacity(reth_proof.account_subtree.len());
     for (k, v) in reth_proof.account_subtree.into_inner() {
-        account_subtree.push((k, v));
+        account_subtree.push((convert_reth_nybbles_to_nibbles(k), v));
     }
     account_subtree.sort_by_key(|a| a.0.clone());
     let mut storages = hash_map_with_capacity(reth_proof.storages.len());
@@ -208,7 +208,7 @@ fn convert_reth_multiproof(
         let mut subtree = Vec::with_capacity(reth_storage_proof.subtree.len());
 
         for (k, v) in reth_storage_proof.subtree.into_inner() {
-            subtree.push((k, v));
+            subtree.push((convert_reth_nybbles_to_nibbles(k), v));
         }
         subtree.sort_by_key(|a| a.0.clone());
         let v = StorageMultiProof { subtree };

--- a/crates/eth-sparse-mpt/src/v1/sparse_mpt/diff_trie/mod.rs
+++ b/crates/eth-sparse-mpt/src/v1/sparse_mpt/diff_trie/mod.rs
@@ -1,7 +1,7 @@
 use crate::utils::{extract_prefix_and_suffix, rlp_pointer, strip_first_nibble_mut, HashMap};
 use alloy_primitives::{keccak256, Bytes, B256};
+use nybbles::Nibbles;
 use parking_lot::Mutex;
-use reth_trie::Nibbles;
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, Seq};
 

--- a/crates/eth-sparse-mpt/src/v1/sparse_mpt/diff_trie/nodes.rs
+++ b/crates/eth-sparse-mpt/src/v1/sparse_mpt/diff_trie/nodes.rs
@@ -3,7 +3,7 @@ use crate::utils::{
     encode_len_extension, encode_len_leaf, encode_null_node, rlp_pointer,
 };
 use alloy_primitives::Bytes;
-use reth_trie::Nibbles;
+use nybbles::Nibbles;
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 use std::sync::Arc;

--- a/crates/eth-sparse-mpt/src/v1/sparse_mpt/fixed_trie.rs
+++ b/crates/eth-sparse-mpt/src/v1/sparse_mpt/fixed_trie.rs
@@ -5,7 +5,7 @@ use alloy_trie::nodes::{
     BranchNode as AlloyBranchNode, ExtensionNode as AlloyExtensionNode, LeafNode as AlloyLeafNode,
     TrieNode as AlloyTrieNode,
 };
-use reth_trie::Nibbles;
+use nybbles::Nibbles;
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, Seq};
 use smallvec::SmallVec;

--- a/crates/eth-sparse-mpt/src/v2/fetch.rs
+++ b/crates/eth-sparse-mpt/src/v2/fetch.rs
@@ -1,12 +1,15 @@
 use std::sync::Arc;
 
-use crate::{utils::HashMap, SparseTrieError};
+use crate::{
+    utils::{convert_nibbles_to_reth_nybbles, convert_reth_nybbles_to_nibbles, HashMap},
+    SparseTrieError,
+};
 use alloy_primitives::map::B256Set;
 use parking_lot::Mutex;
 use rayon::prelude::*;
 
 use alloy_primitives::B256;
-use alloy_trie::Nibbles;
+use nybbles::Nibbles;
 use reth_provider::{
     providers::ConsistentDbView, BlockHashReader, BlockNumReader, BlockReader, DBProvider,
     DatabaseProviderFactory, StateCommitmentProvider,
@@ -87,13 +90,17 @@ impl MissingNodesFetcher {
                         .map_err(SparseTrieError::other)?;
                     *fetched_nodes.lock() += requested_proofs.len();
                     for requested_proof in requested_proofs {
-                        let proof_for_node = storge_multiproof
-                            .subtree
-                            .matching_nodes_sorted(&requested_proof);
+                        let proof_for_node = storge_multiproof.subtree.matching_nodes_sorted(
+                            &convert_nibbles_to_reth_nybbles(requested_proof.clone()),
+                        );
+                        let reth_proof_for_node = proof_for_node
+                            .into_iter()
+                            .map(|(k, v)| (convert_reth_nybbles_to_nibbles(k), v))
+                            .collect();
                         let proof_store =
                             shared_cache.account_proof_store_hashed_address(&hashed_address);
                         proof_store
-                            .add_proof(requested_proof, proof_for_node)
+                            .add_proof(requested_proof, reth_proof_for_node)
                             .map_err(SparseTrieError::other)?;
                     }
                     Ok(())
@@ -127,10 +134,15 @@ impl MissingNodesFetcher {
         for requested_node in self.account_proof_requested_nodes.drain(..) {
             let proof_for_node = multiproof
                 .account_subtree
-                .matching_nodes_sorted(&requested_node);
+                .matching_nodes_sorted(&convert_nibbles_to_reth_nybbles(requested_node.clone()));
+
+            let reth_proof_for_node = proof_for_node
+                .into_iter()
+                .map(|(k, v)| (convert_reth_nybbles_to_nibbles(k), v))
+                .collect();
             shared_cache
                 .account_trie
-                .add_proof(requested_node, proof_for_node)
+                .add_proof(requested_node, reth_proof_for_node)
                 .map_err(SparseTrieError::other)?;
         }
         let fetched_nodes = *fetched_nodes.lock();

--- a/crates/eth-sparse-mpt/src/v2/mod.rs
+++ b/crates/eth-sparse-mpt/src/v2/mod.rs
@@ -5,12 +5,13 @@ use std::time::Instant;
 use alloy_primitives::{keccak256, Address, B256, U256};
 use dashmap::DashMap;
 use fetch::MissingNodesFetcher;
+use nybbles::Nibbles;
 use parking_lot::{Mutex, RwLock};
 use reth_provider::{
     providers::ConsistentDbView, BlockReader, DatabaseProviderFactory, ExecutionOutcome,
     StateCommitmentProvider,
 };
-use reth_trie::{Nibbles, TrieAccount};
+use reth_trie::TrieAccount;
 use revm::state::AccountInfo;
 use rustc_hash::FxBuildHasher;
 use std::ops::Range;

--- a/crates/eth-sparse-mpt/src/v2/trie/mod.rs
+++ b/crates/eth-sparse-mpt/src/v2/trie/mod.rs
@@ -3,9 +3,9 @@ use std::ops::Range;
 use alloy_primitives::{keccak256, B256};
 use alloy_rlp::EMPTY_STRING_CODE;
 use arrayvec::ArrayVec;
+use nybbles::Nibbles;
 use proof_store::ProofNode;
 use proof_store::ProofStore;
-use reth_trie::Nibbles;
 
 pub mod proof_store;
 

--- a/crates/eth-sparse-mpt/src/v2/trie/proof_store.rs
+++ b/crates/eth-sparse-mpt/src/v2/trie/proof_store.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use alloy_trie::nodes::TrieNode as AlloyTrieNode;
 use arrayvec::ArrayVec;
 use dashmap::DashMap;
-use reth_trie::Nibbles;
+use nybbles::Nibbles;
 use rustc_hash::FxBuildHasher;
 
 #[derive(Debug, Clone)]

--- a/crates/rbuilder/Cargo.toml
+++ b/crates/rbuilder/Cargo.toml
@@ -28,6 +28,7 @@ reth-trie-parallel.workspace = true
 reth-node-api.workspace = true
 reth-node-core.workspace = true
 reth-primitives.workspace = true
+reth-ethereum-primitives.workspace = true
 reth-primitives-traits.workspace = true
 reth-provider.workspace = true
 reth-chainspec.workspace = true
@@ -91,8 +92,8 @@ flate2.workspace = true
 # Version required by ethereum-consensus beacon-api-client
 mev-share-sse = { git = "https://github.com/paradigmxyz/mev-share-rs", rev = "9eb2b0138ab3202b9eb3af4b19c7b3bf40b0faa8", default-features = false }
 jsonrpsee = { version = "0.20.3", features = ["full"] }
-beacon-api-client = { git = "https://github.com/ralexstokes/ethereum-consensus/", rev = "ade5ce6c4a19107c1059e5338d8f18855bd2d931" }
-ethereum-consensus = { git = "https://github.com/ralexstokes/ethereum-consensus/", rev = "ade5ce6c4a19107c1059e5338d8f18855bd2d931" }
+beacon-api-client = { git = "https://github.com/ralexstokes/ethereum-consensus/", rev = "5031d31e318dd861cf3373702c5d92f085d926e4" }
+ethereum-consensus = { git = "https://github.com/ralexstokes/ethereum-consensus/", rev = "5031d31e318dd861cf3373702c5d92f085d926e4" }
 uuid = { version = "1.6.1", features = ["serde", "v5", "v4"] }
 prometheus.workspace = true
 warp.workspace = true

--- a/crates/rbuilder/src/backtest/fetch/mod.rs
+++ b/crates/rbuilder/src/backtest/fetch/mod.rs
@@ -26,7 +26,7 @@ use std::{
     sync::{Arc, RwLock},
 };
 use tokio::sync::Mutex;
-use tracing::{info, trace};
+use tracing::{info, trace, warn};
 
 /// Struct that brings block information ([BlockData]) from several [DataSource]s
 /// Filters txs already landed (onchain nonce > tx nonce)
@@ -43,6 +43,7 @@ pub struct HistoricalDataFetcher {
     eth_rpc_parallel: usize,
     data_sources: Vec<Box<dyn DataSource>>,
     payload_delivered_fetcher: PayloadDeliveredFetcher,
+    require_delivered_payload_from_relays: bool,
 }
 
 impl HistoricalDataFetcher {
@@ -52,6 +53,14 @@ impl HistoricalDataFetcher {
             eth_rpc_parallel,
             data_sources: vec![],
             payload_delivered_fetcher: PayloadDeliveredFetcher::default(),
+            require_delivered_payload_from_relays: true,
+        }
+    }
+
+    pub fn with_require_delivered_payload_from_relays(self, require: bool) -> Self {
+        Self {
+            require_delivered_payload_from_relays: require,
+            ..self
         }
     }
 
@@ -135,13 +144,26 @@ impl HistoricalDataFetcher {
     ) -> eyre::Result<(BlockRef, Block, BuilderBlockReceived)> {
         info!(block_number, "Fetching historical data for block");
 
-        info!("Fetching payload delivered");
-        let winning_bid_trace = self.get_payload_delivered_bid_trace(block_number).await?;
-
         info!("Fetching block from eth provider");
         let onchain_block = self.get_onchain_block(block_number).await?;
 
         let block_timestamp: u64 = timestamp_as_u64(&onchain_block);
+
+        info!("Fetching payload delivered");
+        let winning_bid_trace = match self.get_payload_delivered_bid_trace(block_number).await {
+            Ok(res) => res,
+            Err(err) => {
+                if self.require_delivered_payload_from_relays {
+                    return Err(err);
+                } else {
+                    warn!(
+                        ?err,
+                        "Failed to fetch payload from the relay, using fake payload"
+                    );
+                    generate_fake_delivered_payload(&onchain_block)
+                }
+            }
+        };
 
         let block_ref = BlockRef::new(
             block_number,
@@ -296,4 +318,27 @@ pub async fn filter_order_by_nonces(
         .enumerate()
         .filter_map(|(idx, order)| if retain[idx] { Some(order) } else { None })
         .collect())
+}
+
+fn generate_fake_delivered_payload(block: &Block) -> BuilderBlockReceived {
+    BuilderBlockReceived {
+        slot: 0,
+        parent_hash: block.header.parent_hash,
+        block_hash: block.header.hash,
+        builder_pubkey: Default::default(),
+        proposer_pubkey: Default::default(),
+        // insignificant random address
+        proposer_fee_recipient: alloy_primitives::address!(
+            "4e577795E42e1Df9234dc7F572aFd8Cc2777F739"
+        ),
+        gas_limit: block.header.gas_limit,
+        gas_used: block.header.gas_used,
+        value: Default::default(),
+        num_tx: block.transactions.len() as u64,
+        block_number: block.header.number,
+        timestamp: block.header.timestamp,
+        // assume that payload is generated 3 seconds after the slot timestamp
+        timestamp_ms: (block.header.timestamp + 3) * 1000,
+        optimistic_submission: false,
+    }
 }

--- a/crates/rbuilder/src/building/builders/block_building_helper.rs
+++ b/crates/rbuilder/src/building/builders/block_building_helper.rs
@@ -258,7 +258,7 @@ impl BlockBuildingHelperFromProvider {
         );
 
         trace!(
-            block = building_ctx.evm_env.block_env.number,
+            block = building_ctx.evm_env.block_env.number.to_string(),
             build_time_mus = built_block_trace.fill_time.as_micros(),
             finalize_time_mus = built_block_trace.finalize_time.as_micros(),
             root_hash_time_mus = built_block_trace.root_hash_time.as_micros(),

--- a/crates/rbuilder/src/building/builders/mod.rs
+++ b/crates/rbuilder/src/building/builders/mod.rs
@@ -15,7 +15,7 @@ use crate::{
     utils::{is_provider_factory_health_error, NonceCache},
 };
 use ahash::HashSet;
-use alloy_eips::eip4844::BlobTransactionSidecar;
+use alloy_eips::eip7594::BlobTransactionSidecarVariant;
 use alloy_primitives::{Address, Bytes};
 use block_building_helper::BiddableUnfinishedBlock;
 use reth::primitives::SealedBlock;
@@ -35,7 +35,7 @@ pub struct Block {
     pub trace: BuiltBlockTrace,
     pub sealed_block: SealedBlock,
     /// Sidecars for the txs included in SealedBlock
-    pub txs_blobs_sidecars: Vec<Arc<BlobTransactionSidecar>>,
+    pub txs_blobs_sidecars: Vec<Arc<BlobTransactionSidecarVariant>>,
     /// The Pectra execution requests for this bid.
     pub execution_requests: Vec<Bytes>,
     pub builder_name: String,

--- a/crates/rbuilder/src/building/builders/ordering_builder.rs
+++ b/crates/rbuilder/src/building/builders/ordering_builder.rs
@@ -126,6 +126,7 @@ pub fn run_ordering_builder<P, OrderPriorityType>(
         }
 
         let orders = order_intake_consumer.current_block_orders();
+
         match builder.build_block(
             orders,
             use_suggested_fee_recipient_as_coinbase
@@ -160,10 +161,17 @@ pub fn backtest_simulate_block<P, OrderPriorityType: OrderPriority>(
 where
     P: StateProviderFactory + Clone + 'static,
 {
+    let ctx_block_number: u64 = input
+        .ctx
+        .evm_env
+        .block_env
+        .number
+        .try_into()
+        .expect("Block number should be a u64");
     let use_suggested_fee_recipient_as_coinbase = ordering_config.coinbase_payment;
     let state_provider = input
         .provider
-        .history_by_block_number(input.ctx.evm_env.block_env.number - 1)?;
+        .history_by_block_number(ctx_block_number - 1)?;
     let block_orders =
         block_orders_from_sim_orders::<OrderPriorityType>(input.sim_orders, &state_provider)?;
     let mut local_ctx = ThreadBlockBuildingContext::default();

--- a/crates/rbuilder/src/building/evm.rs
+++ b/crates/rbuilder/src/building/evm.rs
@@ -1,4 +1,5 @@
 use crate::building::precompile_cache::{PrecompileCache, WrappedPrecompile};
+use alloy_evm::Database;
 use parking_lot::Mutex;
 use reth_evm::{
     eth::EthEvmContext, EthEvm, EthEvmFactory, Evm, EvmEnv, EvmFactory as RethEvmFactory,
@@ -12,7 +13,7 @@ use revm::{
     inspector::NoOpInspector,
     interpreter::interpreter::EthInterpreter,
     primitives::hardfork::SpecId,
-    Database, Inspector,
+    Inspector,
 };
 use std::sync::Arc;
 

--- a/crates/rbuilder/src/building/evm_inspector.rs
+++ b/crates/rbuilder/src/building/evm_inspector.rs
@@ -2,12 +2,12 @@ use ahash::HashMap;
 use alloy_consensus::Transaction;
 use alloy_primitives::{Address, B256, U256};
 use reth_primitives::{Recovered, TransactionSigned};
+use revm::inspector::Inspector;
 use revm::{
     bytecode::opcode,
     context::ContextTr,
     inspector::JournalExt,
     interpreter::{interpreter_types::Jumps, CallInputs, CallOutcome, Interpreter},
-    Inspector,
 };
 use revm_inspectors::access_list::AccessListInspector;
 

--- a/crates/rbuilder/src/building/mod.rs
+++ b/crates/rbuilder/src/building/mod.rs
@@ -18,9 +18,9 @@ use crate::{
     },
 };
 use alloy_consensus::{constants::KECCAK_EMPTY, Header, EMPTY_OMMER_ROOT_HASH};
+use alloy_eips::eip7594::BlobTransactionSidecarVariant;
 use alloy_eips::{
     eip1559::{calculate_block_gas_limit, ETHEREUM_BLOCK_GAS_LIMIT_30M},
-    eip4844::BlobTransactionSidecar,
     eip4895::Withdrawals,
     eip7685::Requests,
     eip7840::BlobParams,
@@ -50,7 +50,10 @@ use revm::{
     context::BlockEnv,
     context_interface::{block::BlobExcessGasAndPrice, result::InvalidTransaction},
     database::states::bundle_state::BundleRetention,
-    primitives::hardfork::SpecId,
+    primitives::{
+        eip4844::{BLOB_BASE_FEE_UPDATE_FRACTION_CANCUN, BLOB_BASE_FEE_UPDATE_FRACTION_PRAGUE},
+        hardfork::SpecId,
+    },
 };
 use serde::Deserialize;
 use std::{
@@ -234,19 +237,26 @@ impl BlockBuildingContext {
     ) -> BlockBuildingContext {
         let block_number = onchain_block.header.number;
 
-        let blob_excess_gas_and_price =
-            if chain_spec.is_cancun_active_at_timestamp(onchain_block.header.timestamp) {
-                Some(BlobExcessGasAndPrice::new(
-                    onchain_block.header.excess_blob_gas.unwrap_or_default(),
-                    chain_spec.is_prague_active_at_timestamp(onchain_block.header.timestamp),
-                ))
-            } else {
-                None
-            };
+        let blob_excess_gas_and_price = if chain_spec
+            .is_prague_active_at_timestamp(onchain_block.header.timestamp)
+            || chain_spec.is_osaka_active_at_timestamp(onchain_block.header.timestamp)
+        {
+            Some(BlobExcessGasAndPrice::new(
+                onchain_block.header.excess_blob_gas.unwrap_or_default(),
+                BLOB_BASE_FEE_UPDATE_FRACTION_PRAGUE,
+            ))
+        } else if chain_spec.is_cancun_active_at_timestamp(onchain_block.header.timestamp) {
+            Some(BlobExcessGasAndPrice::new(
+                onchain_block.header.excess_blob_gas.unwrap_or_default(),
+                BLOB_BASE_FEE_UPDATE_FRACTION_CANCUN,
+            ))
+        } else {
+            None
+        };
         let block_env = BlockEnv {
-            number: block_number,
+            number: U256::from(block_number),
             beneficiary,
-            timestamp: onchain_block.header.timestamp,
+            timestamp: U256::from(onchain_block.header.timestamp),
             difficulty: onchain_block.header.difficulty,
             prevrandao: Some(onchain_block.header.mix_hash),
             basefee: onchain_block
@@ -339,7 +349,11 @@ impl BlockBuildingContext {
     }
 
     pub fn block(&self) -> u64 {
-        self.evm_env.block_env.number
+        self.evm_env
+            .block_env
+            .number
+            .try_into()
+            .expect("Block number should be a u64")
     }
 
     pub fn coinbase_is_suggested_fee_recipient(&self) -> bool {
@@ -508,7 +522,7 @@ impl ExecutionError {
 pub struct FinalizeResult {
     pub sealed_block: SealedBlock,
     // sidecars for all txs in SealedBlock
-    pub txs_blob_sidecars: Vec<Arc<BlobTransactionSidecar>>,
+    pub txs_blob_sidecars: Vec<Arc<BlobTransactionSidecarVariant>>,
     /// The Pectra execution requests for this bid.
     pub execution_requests: Vec<Bytes>,
 
@@ -836,8 +850,14 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
         let state_root = {
             let (bundle, _) = state.into_parts();
             // we use execution outcome here only for interface compatibility, its just a wrapper around bundle
-            let execution_outcome =
-                ExecutionOutcome::new(bundle, Vec::new(), block_number, Vec::new());
+            let execution_outcome = ExecutionOutcome::new(
+                bundle,
+                Vec::new(),
+                block_number
+                    .try_into()
+                    .expect("Block number should be a u64"),
+                Vec::new(),
+            );
             ctx.root_hasher.state_root(&execution_outcome, local_ctx)?
         };
         let root_hash_time = step_start.elapsed();
@@ -873,11 +893,25 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
         let mut txs_blob_sidecars = Vec::new();
         let (excess_blob_gas, blob_gas_used) = if ctx
             .chain_spec
+            .is_osaka_active_at_timestamp(ctx.attributes.timestamp)
+        {
+            for tx_with_blob in self.executed_tx_infos.iter().map(|info| &info.tx) {
+                if let Some(eip7594_sidecar) = tx_with_blob.blobs_sidecar.as_eip7594() {
+                    if !eip7594_sidecar.blobs.is_empty() {
+                        txs_blob_sidecars.push(tx_with_blob.blobs_sidecar.clone());
+                    }
+                }
+            }
+            (ctx.excess_blob_gas, Some(self.blob_gas_used))
+        } else if ctx
+            .chain_spec
             .is_cancun_active_at_timestamp(ctx.attributes.timestamp)
         {
             for tx_with_blob in self.executed_tx_infos.iter().map(|info| &info.tx) {
-                if !tx_with_blob.blobs_sidecar.blobs.is_empty() {
-                    txs_blob_sidecars.push(tx_with_blob.blobs_sidecar.clone());
+                if let Some(eip4844_sidecar) = tx_with_blob.blobs_sidecar.as_eip4844() {
+                    if !eip4844_sidecar.blobs.is_empty() {
+                        txs_blob_sidecars.push(tx_with_blob.blobs_sidecar.clone());
+                    }
                 }
             }
             (ctx.excess_blob_gas, Some(self.blob_gas_used))
@@ -901,7 +935,9 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
             mix_hash: ctx.attributes.prev_randao,
             nonce: BEACON_NONCE.into(),
             base_fee_per_gas: Some(ctx.evm_env.block_env.basefee),
-            number: block_number,
+            number: block_number
+                .try_into()
+                .expect("Block number should be a u64"),
             gas_limit: ctx.evm_env.block_env.gas_limit,
             difficulty: U256::ZERO,
             gas_used: self.gas_used,

--- a/crates/rbuilder/src/building/mod.rs
+++ b/crates/rbuilder/src/building/mod.rs
@@ -168,13 +168,13 @@ impl BlockBuildingContext {
 
         let excess_blob_gas = if chain_spec.is_cancun_active_at_timestamp(attributes.timestamp) {
             if chain_spec.is_cancun_active_at_timestamp(parent.timestamp) {
-                let blob_params = if chain_spec.is_prague_active_at_timestamp(attributes.timestamp)
+                if let Some(blobs_params) =
+                    chain_spec.blob_params_at_timestamp(attributes.timestamp)
                 {
-                    BlobParams::prague()
+                    parent.next_block_excess_blob_gas(blobs_params)
                 } else {
-                    BlobParams::cancun()
-                };
-                parent.next_block_excess_blob_gas(blob_params)
+                    parent.next_block_excess_blob_gas(BlobParams::cancun())
+                }
             } else {
                 // for the first post-fork block, both parent.blob_gas_used and
                 // parent.excess_blob_gas are evaluated as 0

--- a/crates/rbuilder/src/building/order_commit.rs
+++ b/crates/rbuilder/src/building/order_commit.rs
@@ -20,6 +20,8 @@ use crate::{
 use ahash::HashSet;
 use alloy_consensus::{constants::KECCAK_EMPTY, Transaction};
 use alloy_eips::eip4844::DATA_GAS_PER_BLOB;
+use alloy_eips::eip7594::BlobTransactionSidecarVariant;
+use alloy_evm::Database;
 use alloy_primitives::{Address, B256, I256, U256};
 use itertools::Itertools;
 use reth::revm::database::StateProviderDatabase;
@@ -31,7 +33,7 @@ use revm::{
     context::result::{ExecutionResult, ResultAndState},
     context_interface::result::{EVMError, InvalidTransaction},
     database::{states::bundle_state::BundleRetention, BundleState, State},
-    Database, DatabaseCommit,
+    Database as _, DatabaseCommit,
 };
 use std::{collections::HashMap, sync::Arc};
 use thiserror::Error;
@@ -435,7 +437,15 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
     ) -> Result<Result<TransactionOk, TransactionErr>, CriticalCommitOrderError> {
         let coinbase_balance_before = I256::try_from(self.coinbase_balance()?)?;
         // Use blobs.len() instead of checking for tx type just in case in the future some other new txs have blobs
-        let blob_gas_used = tx_with_blobs.blobs_sidecar.blobs.len() as u64 * DATA_GAS_PER_BLOB;
+        let blob_gas_used = match tx_with_blobs.blobs_sidecar.as_ref() {
+            BlobTransactionSidecarVariant::Eip4844(eip4844_sidecar) => {
+                eip4844_sidecar.blobs.len() as u64 * DATA_GAS_PER_BLOB
+            }
+            BlobTransactionSidecarVariant::Eip7594(eip7594_sidecar) => {
+                eip7594_sidecar.blobs.len() as u64 * DATA_GAS_PER_BLOB
+            }
+        };
+
         if cumulative_blob_gas_used + blob_gas_used > self.ctx.max_blob_gas_per_block() {
             return Ok(Err(TransactionErr::BlobGasLeft));
         }
@@ -591,9 +601,11 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
         let current_block = self.ctx.evm_env.block_env.number;
         // None is good for any block
         if let Some(block) = bundle.block {
-            if block != current_block {
+            if U256::from(block) != current_block {
                 return Ok(Err(BundleErr::TargetBlockIncorrect {
-                    block: current_block,
+                    block: current_block
+                        .try_into()
+                        .expect("Block number should be a u64"),
                     target_block: block,
                     target_max_block: block,
                 }));
@@ -605,11 +617,11 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
             bundle.max_timestamp.unwrap_or(u64::MAX),
             self.ctx.evm_env.block_env.timestamp,
         );
-        if !(min_ts <= block_ts && block_ts <= max_ts) {
+        if !(U256::from(min_ts) <= block_ts && block_ts <= U256::from(max_ts)) {
             return Ok(Err(BundleErr::IncorrectTimestamp {
                 min: min_ts,
                 max: max_ts,
-                block: block_ts,
+                block: block_ts.try_into().expect("Block number should be a u64"),
             }));
         }
 
@@ -863,9 +875,13 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
         allow_tx_skip: bool,
     ) -> Result<Result<BundleOk, BundleErr>, CriticalCommitOrderError> {
         let current_block = self.ctx.evm_env.block_env.number;
-        if !(bundle.block <= current_block && current_block <= bundle.max_block) {
+        if !(U256::from(bundle.block) <= current_block
+            && current_block <= U256::from(bundle.max_block))
+        {
             return Ok(Err(BundleErr::TargetBlockIncorrect {
-                block: current_block,
+                block: current_block
+                    .try_into()
+                    .expect("Block number should be a u64"),
                 target_block: bundle.block,
                 target_max_block: bundle.max_block,
             }));

--- a/crates/rbuilder/src/building/testing/bundle_tests/mod.rs
+++ b/crates/rbuilder/src/building/testing/bundle_tests/mod.rs
@@ -1,10 +1,5 @@
 pub mod setup;
 
-use alloy_primitives::{Address, Bytes, B256, U256};
-use itertools::Itertools;
-use reth_primitives::Bytecode;
-use std::collections::{HashMap, HashSet};
-
 use crate::{
     building::{
         testing::bundle_tests::setup::NonceValue, BuiltBlockTrace, BundleErr, ExecutionResult,
@@ -13,6 +8,10 @@ use crate::{
     primitives::{Bundle, BundleRefund, Order, OrderId, Refund, RefundConfig, TxRevertBehavior},
     utils::{constants::BASE_TX_GAS, int_percentage},
 };
+use alloy_primitives::{Address, Bytes, B256, U256};
+use itertools::Itertools;
+use reth_primitives::Bytecode;
+use std::collections::{HashMap, HashSet};
 
 use self::setup::TestSetup;
 
@@ -97,6 +96,7 @@ fn test_target_block() -> eyre::Result<()> {
 
         test_setup.begin_bundle_order(NEXT_BUILT_BLOCK_NUMBER);
         test_setup.add_dummy_tx_0_1_no_rev()?;
+
         commit_order_err_matches!(
             test_setup,
             OrderErr::Bundle(BundleErr::TargetBlockIncorrect {
@@ -135,6 +135,7 @@ fn test_target_block() -> eyre::Result<()> {
 
         test_setup.begin_share_bundle_order(PREV_PREV_BUILT_BLOCK_NUMBER, PREV_BUILT_BLOCK_NUMBER);
         test_setup.add_dummy_tx_0_1_no_rev()?;
+
         commit_order_err_matches!(
             test_setup,
             OrderErr::Bundle(BundleErr::TargetBlockIncorrect {

--- a/crates/rbuilder/src/building/tx_sim_cache/result_store.rs
+++ b/crates/rbuilder/src/building/tx_sim_cache/result_store.rs
@@ -132,7 +132,6 @@ impl<R: Clone + std::fmt::Debug> ExecutionResultStoreWalker<R> {
 #[cfg(test)]
 mod tests {
     use crate::utils::test_utils::{addr, u256};
-    use reth::revm::state::CodeSize;
 
     use super::*;
 
@@ -146,7 +145,6 @@ mod tests {
                 nonce: 0,
                 code_hash: Default::default(),
                 code: None,
-                code_size: CodeSize::Known(0),
             }),
         }
     }

--- a/crates/rbuilder/src/building/tx_sim_cache/result_store.rs
+++ b/crates/rbuilder/src/building/tx_sim_cache/result_store.rs
@@ -132,6 +132,7 @@ impl<R: Clone + std::fmt::Debug> ExecutionResultStoreWalker<R> {
 #[cfg(test)]
 mod tests {
     use crate::utils::test_utils::{addr, u256};
+    use reth::revm::state::CodeSize;
 
     use super::*;
 
@@ -145,6 +146,7 @@ mod tests {
                 nonce: 0,
                 code_hash: Default::default(),
                 code: None,
+                code_size: CodeSize::Known(0),
             }),
         }
     }

--- a/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
+++ b/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
@@ -209,6 +209,7 @@ async fn run_submit_to_relays_job(
             .included_orders
             .iter()
             .flat_map(|exec_res| exec_res.order.original_orders());
+
         let bid_metadata = BidMetadata {
             value: BidValueMetadata {
                 coinbase_reward: block.trace.coinbase_reward,

--- a/crates/rbuilder/src/live_builder/building/mod.rs
+++ b/crates/rbuilder/src/live_builder/building/mod.rs
@@ -108,7 +108,12 @@ where
             );
         // sink removal is automatic via OrderSink::is_alive false
         let _block_sub = self.orderpool_subscriber.add_sink(
-            block_ctx.evm_env.block_env.number,
+            block_ctx
+                .evm_env
+                .block_env
+                .number
+                .try_into()
+                .expect("Block number should be a u64"),
             Box::new(mempool_txs_detector_sniffer),
         );
 
@@ -142,7 +147,7 @@ where
         for builder in self.builders.iter() {
             let builder_name = builder.name();
             debug!(
-                block = block_number,
+                block = block_number.to_string(),
                 payload_id = ctx.payload_id,
                 builder_name,
                 "Spawning builder job"
@@ -158,7 +163,7 @@ where
             tokio::task::spawn_blocking(move || {
                 builder.build_blocks(input);
                 debug!(
-                    block = block_number,
+                    block = block_number.to_string(),
                     payload_id = ctx.payload_id,
                     builder_name,
                     "Stopped builder job"

--- a/crates/rbuilder/src/live_builder/config.rs
+++ b/crates/rbuilder/src/live_builder/config.rs
@@ -46,6 +46,7 @@ use crate::{
 };
 use alloy_chains::ChainKind;
 use alloy_primitives::{
+    hex,
     utils::{format_ether, parse_ether},
     FixedBytes, B256, U256,
 };
@@ -286,7 +287,8 @@ impl L1Config {
 
         let relay_secret_key = if let Some(secret_key) = &self.relay_secret_key {
             let resolved_key = secret_key.value()?;
-            SecretKey::try_from(resolved_key)?
+            let input = hex::decode(resolved_key)?;
+            SecretKey::from_bytes(&input)?
         } else {
             warn!("No relay secret key provided. A random key will be generated.");
             SecretKey::random(&mut rand::thread_rng())?

--- a/crates/rbuilder/src/live_builder/config.rs
+++ b/crates/rbuilder/src/live_builder/config.rs
@@ -63,8 +63,8 @@ use reth_primitives::StaticFileSegment;
 use reth_provider::StaticFileProviderFactory;
 use serde::Deserialize;
 use serde_with::{serde_as, OneOrMany};
-use std::collections::HashMap;
 use std::{
+    collections::HashMap,
     fmt::Debug,
     path::{Path, PathBuf},
     str::FromStr,
@@ -762,6 +762,7 @@ lazy_static! {
                 authorization_header: None,
                 builder_id_header: None,
                 api_token_header: None,
+                adjustment_fee_payer: None,
                 ask_for_filtering_validators: None,
                 can_ignore_gas_limit: None,
             },
@@ -783,6 +784,7 @@ lazy_static! {
                 authorization_header: None,
                 builder_id_header: None,
                 api_token_header: None,
+                adjustment_fee_payer: None,
                 ask_for_filtering_validators: None,
                 can_ignore_gas_limit: None,
             },
@@ -804,6 +806,7 @@ lazy_static! {
                 authorization_header: None,
                 builder_id_header: None,
                 api_token_header: None,
+                adjustment_fee_payer: None,
                 ask_for_filtering_validators: None,
                 can_ignore_gas_limit: None,
             },
@@ -824,6 +827,7 @@ lazy_static! {
                 authorization_header: None,
                 builder_id_header: None,
                 api_token_header: None,
+                adjustment_fee_payer: None,
                 ask_for_filtering_validators: None,
                 can_ignore_gas_limit: None,
             },
@@ -845,6 +849,7 @@ lazy_static! {
                 authorization_header: None,
                 builder_id_header: None,
                 api_token_header: None,
+                adjustment_fee_payer: None,
                 ask_for_filtering_validators: None,
                 can_ignore_gas_limit: None,
             },

--- a/crates/rbuilder/src/live_builder/order_input/txpool_fetcher.rs
+++ b/crates/rbuilder/src/live_builder/order_input/txpool_fetcher.rs
@@ -117,6 +117,7 @@ mod test {
 
     use super::*;
     use alloy_consensus::{SidecarBuilder, SimpleCoder};
+    use alloy_eips::eip7594::BlobTransactionSidecarVariant;
     use alloy_network::{EthereumWallet, TransactionBuilder};
     use alloy_node_bindings::Anvil;
     use alloy_primitives::U256;
@@ -182,8 +183,12 @@ mod test {
         }
         .unwrap();
 
+        let blob_len = match tx_with_blobs.blobs_sidecar.as_ref() {
+            BlobTransactionSidecarVariant::Eip4844(b_4844) => b_4844.blobs.len(),
+            BlobTransactionSidecarVariant::Eip7594(b_7954) => b_7954.blobs.len(),
+        };
         assert_eq!(tx_with_blobs.hash(), *pending_tx.tx_hash());
-        assert_eq!(tx_with_blobs.blobs_sidecar.blobs.len(), 1);
+        assert_eq!(blob_len, 1);
 
         // send another tx without blobs
         let tx = TransactionRequest::default()
@@ -205,6 +210,11 @@ mod test {
         .unwrap();
 
         assert_eq!(tx_without_blobs.hash(), *pending_tx.tx_hash());
-        assert_eq!(tx_without_blobs.blobs_sidecar.blobs.len(), 0);
+        let blob_len = match tx_without_blobs.blobs_sidecar.as_ref() {
+            BlobTransactionSidecarVariant::Eip4844(b_4844) => b_4844.blobs.len(),
+            BlobTransactionSidecarVariant::Eip7594(b_7954) => b_7954.blobs.len(),
+        };
+
+        assert_eq!(blob_len, 0);
     }
 }

--- a/crates/rbuilder/src/live_builder/simulation/mod.rs
+++ b/crates/rbuilder/src/live_builder/simulation/mod.rs
@@ -130,7 +130,7 @@ where
         let provider = self.provider.clone();
         let current_contexts = Arc::clone(&self.current_contexts);
         let block_context: BlockContextId = gen_uid();
-        let span = info_span!("sim_ctx", block = ctx.evm_env.block_env.number, parent = ?ctx.attributes.parent);
+        let span = info_span!("sim_ctx", block = ctx.evm_env.block_env.number.to_string(), parent = ?ctx.attributes.parent);
 
         let handle = tokio::spawn(
             async move {

--- a/crates/rbuilder/src/mev_boost/adjustment.rs
+++ b/crates/rbuilder/src/mev_boost/adjustment.rs
@@ -1,0 +1,42 @@
+use alloy_primitives::{Address, Bytes, B256};
+
+/// The type representing UltraSound bid adjustments.
+#[derive(
+    PartialEq,
+    Eq,
+    Clone,
+    Debug,
+    serde::Serialize,
+    serde::Deserialize,
+    ssz_derive::Encode,
+    ssz_derive::Decode,
+)]
+pub struct BidAdjustmentData {
+    /// State root of the payload.
+    pub state_root: B256,
+    /// Transactions root of the payload.
+    pub transactions_root: B256,
+    /// Receipts root of the payload.
+    pub receipts_root: B256,
+    /// The usual builder address that pays the proposer in the last transaction of the block.
+    /// When we adjust a bid, this transaction is overwritten by a transaction from the collateral
+    /// account `fee_payer_address`. If we don't adjust the bid, `builder_address` pays the
+    /// proposer as per usual.
+    pub builder_address: Address,
+    /// The state proof for the builder account.
+    pub builder_proof: Vec<Bytes>,
+    /// The proposer's fee recipient.
+    pub fee_recipient_address: Address,
+    /// The state proof for the fee recipient account.
+    pub fee_recipient_proof: Vec<Bytes>,
+    /// The fee payer address that is custodied by the relay.
+    pub fee_payer_address: Address,
+    /// The state proof for the fee payer account.
+    pub fee_payer_proof: Vec<Bytes>,
+    /// The merkle proof for the last transaction in the block, which will be overwritten with a
+    /// payment from `fee_payer` to `fee_recipient` if we adjust the bid.
+    pub placeholder_transaction_proof: Vec<Bytes>,
+    /// The merkle proof for the receipt of the placeholder transaction. It's required for
+    /// adjusting payments to contract addresses.
+    pub placeholder_receipt_proof: Vec<Bytes>,
+}

--- a/crates/rbuilder/src/mev_boost/mod.rs
+++ b/crates/rbuilder/src/mev_boost/mod.rs
@@ -1,3 +1,4 @@
+pub mod adjustment;
 mod error;
 pub mod fake_mev_boost_relay;
 pub mod rpc;
@@ -18,7 +19,7 @@ use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr};
 use ssz::Encode;
 use std::{io::Write, str::FromStr};
-use submission::{SubmitBlockRequest, SubmitBlockRequestNoBlobs, SubmitBlockRequestWithMetadata};
+use submission::{SubmitBlockRequestNoBlobs, SubmitBlockRequestWithMetadata};
 use url::Url;
 
 pub use error::*;
@@ -500,11 +501,7 @@ impl RelayClient {
         // SSZ vs JSON
         let (mut body_data, content_type) = if ssz {
             (
-                match &submission_with_metadata.submission {
-                    SubmitBlockRequest::Capella(data) => data.0.as_ssz_bytes(),
-                    SubmitBlockRequest::Deneb(data) => data.0.as_ssz_bytes(),
-                    SubmitBlockRequest::Electra(data) => data.0.as_ssz_bytes(),
-                },
+                submission_with_metadata.submission.as_ssz_bytes(),
                 SSZ_CONTENT_TYPE,
             )
         } else {
@@ -694,7 +691,9 @@ mod tests {
     use submission::{BidMetadata, BidValueMetadata};
 
     use super::{rpc::TestDataGenerator, *};
-    use crate::mev_boost::fake_mev_boost_relay::FakeMevBoostRelay;
+    use crate::mev_boost::{
+        fake_mev_boost_relay::FakeMevBoostRelay, submission::SubmitBlockRequest,
+    };
 
     use std::str::FromStr;
 

--- a/crates/rbuilder/src/mev_boost/rpc.rs
+++ b/crates/rbuilder/src/mev_boost/rpc.rs
@@ -19,12 +19,15 @@ pub struct TestDataGenerator {
 
 impl TestDataGenerator {
     pub fn create_deneb_submit_block_request(&mut self) -> DenebSubmitBlockRequest {
-        DenebSubmitBlockRequest(SignedBidSubmissionV3 {
-            message: self.create_bid_trace(),
-            execution_payload: self.create_deneb_payload(),
-            blobs_bundle: self.create_txs_blobs_sidecars(),
-            signature: self.create_signature(),
-        })
+        DenebSubmitBlockRequest {
+            submission: SignedBidSubmissionV3 {
+                message: self.create_bid_trace(),
+                execution_payload: self.create_deneb_payload(),
+                blobs_bundle: self.create_txs_blobs_sidecars(),
+                signature: self.create_signature(),
+            },
+            adjustment_data: None,
+        }
     }
 
     pub fn create_txs_blobs_sidecars(&mut self) -> BlobsBundleV1 {

--- a/crates/rbuilder/src/mev_boost/sign_payload.rs
+++ b/crates/rbuilder/src/mev_boost/sign_payload.rs
@@ -1,18 +1,21 @@
 use super::submission::{
     CapellaSubmitBlockRequest, DenebSubmitBlockRequest, ElectraSubmitBlockRequest,
-    SubmitBlockRequest,
+    FuluSubmitBlockRequest, SubmitBlockRequest,
 };
 use crate::utils::u256decimal_serde_helper;
-use alloy_eips::{eip2718::Encodable2718, eip4844::BlobTransactionSidecar, eip7685::Requests};
+use alloy_eips::eip7594::{BlobTransactionSidecarEip7594, BlobTransactionSidecarVariant};
+use alloy_eips::eip7685::Requests;
+use alloy_eips::{eip2718::Encodable2718, eip4844::BlobTransactionSidecar};
 use alloy_primitives::{Address, BlockHash, Bytes, FixedBytes, B256, U256};
+use alloy_rpc_types_beacon::relay::SignedBidSubmissionV5;
+use alloy_rpc_types_beacon::requests::ExecutionRequestsV4;
 use alloy_rpc_types_beacon::{
     events::PayloadAttributesData,
     relay::{BidTrace, SignedBidSubmissionV2, SignedBidSubmissionV3, SignedBidSubmissionV4},
-    requests::ExecutionRequestsV4,
     BlsPublicKey,
 };
 use alloy_rpc_types_engine::{
-    BlobsBundleV1, ExecutionPayloadV1, ExecutionPayloadV2, ExecutionPayloadV3,
+    BlobsBundleV1, BlobsBundleV2, ExecutionPayloadV1, ExecutionPayloadV2, ExecutionPayloadV3,
 };
 use alloy_rpc_types_eth::Withdrawal;
 use ethereum_consensus::{
@@ -119,7 +122,7 @@ fn a2e_address(a: &Address) -> ExecutionAddress {
 pub fn sign_block_for_relay(
     signer: &BLSBlockSigner,
     sealed_block: &SealedBlock,
-    blobs_bundle: &[Arc<BlobTransactionSidecar>],
+    blobs_bundle: &[Arc<BlobTransactionSidecarVariant>],
     execution_requests: &[Bytes], // The Pectra execution requests for this bid.
     chain_spec: &ChainSpec,
     attrs: &PayloadAttributesData,
@@ -198,10 +201,23 @@ pub fn sign_block_for_relay(
                 .expect("deneb block does not have excess blob gas"),
         };
 
-        let blobs_bundle = marshal_txs_blobs_sidecars(blobs_bundle);
         let execution_requests =
             ExecutionRequestsV4::try_from(Requests::new(execution_requests.to_vec()))?;
-        if chain_spec.is_prague_active_at_timestamp(sealed_block.timestamp) {
+
+        if chain_spec.is_osaka_active_at_timestamp(sealed_block.timestamp) {
+            let blobs_bundle_v2 = marshall_txs_blobs_sidecars_v2(blobs_bundle);
+
+            let submission = SignedBidSubmissionV5 {
+                message,
+                execution_payload,
+                blobs_bundle: blobs_bundle_v2,
+                signature,
+                execution_requests,
+            };
+            SubmitBlockRequest::fulu(FuluSubmitBlockRequest::new(submission, adjustment_data))
+        } else if chain_spec.is_prague_active_at_timestamp(sealed_block.timestamp) {
+            let blobs_bundle = marshal_txs_blobs_sidecars(blobs_bundle);
+
             let submission = SignedBidSubmissionV4 {
                 message,
                 execution_payload,
@@ -211,6 +227,8 @@ pub fn sign_block_for_relay(
             };
             SubmitBlockRequest::electra(ElectraSubmitBlockRequest::new(submission, adjustment_data))
         } else {
+            let blobs_bundle = marshal_txs_blobs_sidecars(blobs_bundle);
+
             let submission = SignedBidSubmissionV3 {
                 message,
                 execution_payload,
@@ -231,23 +249,67 @@ pub fn sign_block_for_relay(
     Ok(request)
 }
 
-fn flatten_marshal<Source>(
-    txs_blobs_sidecars: &[Arc<BlobTransactionSidecar>],
-    vec_getter: impl Fn(&Arc<BlobTransactionSidecar>) -> Vec<Source>,
-) -> Vec<Source> {
-    let flatten_data = txs_blobs_sidecars.iter().flat_map(vec_getter);
-    flatten_data.collect::<Vec<Source>>()
-}
+fn marshal_txs_blobs_sidecars(
+    txs_blobs_sidecars: &[Arc<BlobTransactionSidecarVariant>],
+) -> BlobsBundleV1 {
+    // Instead of collecting Arc<BlobTransactionSidecar>, just collect references to the inner struct.
+    let eip4844_sidecars: Vec<&BlobTransactionSidecar> = txs_blobs_sidecars
+        .iter()
+        .filter_map(|blob| blob.as_ref().as_eip4844())
+        .collect();
 
-fn marshal_txs_blobs_sidecars(txs_blobs_sidecars: &[Arc<BlobTransactionSidecar>]) -> BlobsBundleV1 {
-    let rpc_commitments = flatten_marshal(txs_blobs_sidecars, |t| t.commitments.clone());
-    let rpc_proofs = flatten_marshal(txs_blobs_sidecars, |t| t.proofs.clone());
-    let rpc_blobs = flatten_marshal(txs_blobs_sidecars, |t| t.blobs.clone());
+    // Now flatten the fields, only cloning the inner data, not the whole struct or Arc.
+    let commitments = eip4844_sidecars
+        .iter()
+        .flat_map(|t| t.commitments.iter().cloned())
+        .collect();
+
+    let proofs = eip4844_sidecars
+        .iter()
+        .flat_map(|t| t.proofs.iter().cloned())
+        .collect();
+
+    let blobs = eip4844_sidecars
+        .iter()
+        .flat_map(|t| t.blobs.iter().cloned())
+        .collect();
 
     BlobsBundleV1 {
-        commitments: rpc_commitments,
-        proofs: rpc_proofs,
-        blobs: rpc_blobs,
+        commitments,
+        proofs,
+        blobs,
+    }
+}
+
+fn marshall_txs_blobs_sidecars_v2(
+    txs_blobs_sidecars: &[Arc<BlobTransactionSidecarVariant>],
+) -> BlobsBundleV2 {
+    // Instead of collecting Arc<BlobTransactionSidecarEip7594>, just collect references to the inner struct.
+    let eip7594_sidecars: Vec<&BlobTransactionSidecarEip7594> = txs_blobs_sidecars
+        .iter()
+        .filter_map(|blob| blob.as_ref().as_eip7594())
+        .collect();
+
+    // Now flatten the fields, only cloning the inner data, not the whole struct or Arc.
+    let commitments = eip7594_sidecars
+        .iter()
+        .flat_map(|t| t.commitments.iter().cloned())
+        .collect();
+
+    let proofs = eip7594_sidecars
+        .iter()
+        .flat_map(|t| t.cell_proofs.iter().cloned())
+        .collect();
+
+    let blobs = eip7594_sidecars
+        .iter()
+        .flat_map(|t| t.blobs.iter().cloned())
+        .collect();
+
+    BlobsBundleV2 {
+        commitments,
+        proofs,
+        blobs,
     }
 }
 

--- a/crates/rbuilder/src/mev_boost/sign_payload.rs
+++ b/crates/rbuilder/src/mev_boost/sign_payload.rs
@@ -3,13 +3,12 @@ use super::submission::{
     SubmitBlockRequest,
 };
 use crate::utils::u256decimal_serde_helper;
-use alloy_eips::eip7685::Requests;
-use alloy_eips::{eip2718::Encodable2718, eip4844::BlobTransactionSidecar};
+use alloy_eips::{eip2718::Encodable2718, eip4844::BlobTransactionSidecar, eip7685::Requests};
 use alloy_primitives::{Address, BlockHash, Bytes, FixedBytes, B256, U256};
-use alloy_rpc_types_beacon::requests::ExecutionRequestsV4;
 use alloy_rpc_types_beacon::{
     events::PayloadAttributesData,
     relay::{BidTrace, SignedBidSubmissionV2, SignedBidSubmissionV3, SignedBidSubmissionV4},
+    requests::ExecutionRequestsV4,
     BlsPublicKey,
 };
 use alloy_rpc_types_engine::{
@@ -127,6 +126,9 @@ pub fn sign_block_for_relay(
     pubkey: H384,
     value: U256,
 ) -> eyre::Result<SubmitBlockRequest> {
+    // TODO: add support for bid adjustments
+    let adjustment_data = None;
+
     let message = BidTrace {
         slot: attrs.proposal_slot,
         parent_hash: attrs.parent_block_hash,
@@ -185,7 +187,7 @@ pub fn sign_block_for_relay(
             .unwrap_or_default(),
     };
 
-    let submit_block_request = if chain_spec.is_cancun_active_at_timestamp(sealed_block.timestamp) {
+    let request = if chain_spec.is_cancun_active_at_timestamp(sealed_block.timestamp) {
         let execution_payload = ExecutionPayloadV3 {
             payload_inner: capella_payload,
             blob_gas_used: sealed_block
@@ -200,31 +202,33 @@ pub fn sign_block_for_relay(
         let execution_requests =
             ExecutionRequestsV4::try_from(Requests::new(execution_requests.to_vec()))?;
         if chain_spec.is_prague_active_at_timestamp(sealed_block.timestamp) {
-            SubmitBlockRequest::Electra(ElectraSubmitBlockRequest(SignedBidSubmissionV4 {
+            let submission = SignedBidSubmissionV4 {
                 message,
                 execution_payload,
                 blobs_bundle,
                 signature,
                 execution_requests,
-            }))
+            };
+            SubmitBlockRequest::electra(ElectraSubmitBlockRequest::new(submission, adjustment_data))
         } else {
-            SubmitBlockRequest::Deneb(DenebSubmitBlockRequest(SignedBidSubmissionV3 {
+            let submission = SignedBidSubmissionV3 {
                 message,
                 execution_payload,
                 blobs_bundle,
                 signature,
-            }))
+            };
+            SubmitBlockRequest::deneb(DenebSubmitBlockRequest::new(submission, adjustment_data))
         }
     } else {
-        let execution_payload = capella_payload;
-        SubmitBlockRequest::Capella(CapellaSubmitBlockRequest(SignedBidSubmissionV2 {
+        let submission = SignedBidSubmissionV2 {
             message,
-            execution_payload,
+            execution_payload: capella_payload,
             signature,
-        }))
+        };
+        SubmitBlockRequest::capella(CapellaSubmitBlockRequest::new(submission, adjustment_data))
     };
 
-    Ok(submit_block_request)
+    Ok(request)
 }
 
 fn flatten_marshal<Source>(

--- a/crates/rbuilder/src/mev_boost/submission.rs
+++ b/crates/rbuilder/src/mev_boost/submission.rs
@@ -4,28 +4,16 @@ use alloy_rpc_types_beacon::{
     requests::ExecutionRequestsV4,
     BlsSignature,
 };
-use alloy_rpc_types_engine::{BlobsBundleV1, ExecutionPayloadV3};
+use alloy_rpc_types_engine::{BlobsBundleV1, ExecutionPayloadV2, ExecutionPayloadV3};
+use derive_more::Deref;
 use serde::{Deserialize, Serialize};
-use ssz::{Decode, DecodeError, Encode};
+use ssz::DecodeError;
 
+use super::adjustment::BidAdjustmentData;
 use crate::primitives::OrderId;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct ElectraSubmitBlockRequest(pub SignedBidSubmissionV4);
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct DenebSubmitBlockRequest(pub SignedBidSubmissionV3);
-
-impl DenebSubmitBlockRequest {
-    pub fn as_ssz_bytes(&self) -> Vec<u8> {
-        self.0.as_ssz_bytes()
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct CapellaSubmitBlockRequest(pub SignedBidSubmissionV2);
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ssz_derive::Encode)]
+#[ssz(enum_behaviour = "transparent")]
 #[serde(untagged)]
 pub enum SubmitBlockRequest {
     Capella(CapellaSubmitBlockRequest),
@@ -34,28 +22,344 @@ pub enum SubmitBlockRequest {
 }
 
 impl SubmitBlockRequest {
-    pub fn bid_trace(&self) -> &BidTrace {
-        match self {
-            SubmitBlockRequest::Capella(req) => &req.0.message,
-            SubmitBlockRequest::Deneb(req) => &req.0.message,
-            SubmitBlockRequest::Electra(req) => &req.0.message,
-        }
+    #[inline]
+    pub fn capella(request: CapellaSubmitBlockRequest) -> Self {
+        Self::Capella(request)
     }
 
-    pub fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, DecodeError> {
-        if let Ok(result) = SignedBidSubmissionV4::from_ssz_bytes(bytes) {
-            return Ok(SubmitBlockRequest::Electra(ElectraSubmitBlockRequest(
-                result,
-            )));
+    #[inline]
+    pub fn deneb(request: DenebSubmitBlockRequest) -> Self {
+        Self::Deneb(request)
+    }
+
+    #[inline]
+    pub fn electra(request: ElectraSubmitBlockRequest) -> Self {
+        Self::Electra(request)
+    }
+
+    pub fn bid_trace(&self) -> &BidTrace {
+        match self {
+            SubmitBlockRequest::Capella(req) => &req.message,
+            SubmitBlockRequest::Deneb(req) => &req.message,
+            SubmitBlockRequest::Electra(req) => &req.message,
         }
-        if let Ok(result) = SignedBidSubmissionV3::from_ssz_bytes(bytes) {
-            return Ok(SubmitBlockRequest::Deneb(DenebSubmitBlockRequest(result)));
+    }
+}
+
+impl ssz::Decode for SubmitBlockRequest {
+    fn is_ssz_fixed_len() -> bool {
+        false
+    }
+
+    fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, DecodeError> {
+        if let Ok(result) = ElectraSubmitBlockRequest::from_ssz_bytes(bytes) {
+            return Ok(Self::electra(result));
+        }
+        if let Ok(result) = DenebSubmitBlockRequest::from_ssz_bytes(bytes) {
+            return Ok(Self::deneb(result));
         }
 
-        let result = SignedBidSubmissionV2::from_ssz_bytes(bytes)?;
-        Ok(SubmitBlockRequest::Capella(CapellaSubmitBlockRequest(
-            result,
-        )))
+        let result = CapellaSubmitBlockRequest::from_ssz_bytes(bytes)?;
+        Ok(Self::capella(result))
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Deref)]
+pub struct ElectraSubmitBlockRequest {
+    /// Inner bid submission.
+    #[deref]
+    #[serde(flatten)]
+    pub submission: SignedBidSubmissionV4,
+    /// Bid adjustment data if present.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub adjustment_data: Option<BidAdjustmentData>,
+}
+
+impl ElectraSubmitBlockRequest {
+    /// Create new Electra submit block request.
+    pub fn new(
+        submission: SignedBidSubmissionV4,
+        adjustment_data: Option<BidAdjustmentData>,
+    ) -> Self {
+        Self {
+            submission,
+            adjustment_data,
+        }
+    }
+}
+
+impl ssz::Encode for ElectraSubmitBlockRequest {
+    fn is_ssz_fixed_len() -> bool {
+        false
+    }
+
+    fn ssz_append(&self, buf: &mut Vec<u8>) {
+        let mut offset = <BidTrace as ssz::Encode>::ssz_fixed_len()
+            + <ExecutionPayloadV3 as ssz::Encode>::ssz_fixed_len()
+            + <BlobsBundleV1 as ssz::Encode>::ssz_fixed_len()
+            + <ExecutionRequestsV4 as ssz::Encode>::ssz_fixed_len()
+            + <BlsSignature as ssz::Encode>::ssz_fixed_len();
+        if self.adjustment_data.is_some() {
+            offset += <BidAdjustmentData as ssz::Encode>::ssz_fixed_len();
+        }
+
+        let mut encoder = ssz::SszEncoder::container(buf, offset);
+
+        encoder.append(&self.message);
+        encoder.append(&self.execution_payload);
+        encoder.append(&self.blobs_bundle);
+        encoder.append(&self.execution_requests);
+        encoder.append(&self.signature);
+        if let Some(adjustment) = &self.adjustment_data {
+            encoder.append(&adjustment);
+        }
+
+        encoder.finalize();
+    }
+
+    fn ssz_bytes_len(&self) -> usize {
+        let mut len = <BidTrace as ssz::Encode>::ssz_bytes_len(&self.message)
+            + <ExecutionPayloadV3 as ssz::Encode>::ssz_bytes_len(&self.execution_payload)
+            + <BlobsBundleV1 as ssz::Encode>::ssz_bytes_len(&self.blobs_bundle)
+            + <ExecutionRequestsV4 as ssz::Encode>::ssz_bytes_len(&self.execution_requests)
+            + <BlsSignature as ssz::Encode>::ssz_bytes_len(&self.signature);
+        if let Some(adjustment) = &self.adjustment_data {
+            len += <BidAdjustmentData as ssz::Encode>::ssz_bytes_len(adjustment);
+        }
+        len
+    }
+}
+
+impl ssz::Decode for ElectraSubmitBlockRequest {
+    fn is_ssz_fixed_len() -> bool {
+        false
+    }
+
+    fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, DecodeError> {
+        #[derive(ssz_derive::Decode)]
+        struct ElectraSubmitBlockRequestSszHelper {
+            message: BidTrace,
+            execution_payload: ExecutionPayloadV3,
+            blobs_bundle: BlobsBundleV1,
+            execution_requests: ExecutionRequestsV4,
+            signature: BlsSignature,
+            adjustment_data: BidAdjustmentData,
+        }
+
+        if let Ok(request) = ElectraSubmitBlockRequestSszHelper::from_ssz_bytes(bytes) {
+            let ElectraSubmitBlockRequestSszHelper {
+                message,
+                execution_payload,
+                blobs_bundle,
+                execution_requests,
+                signature,
+                adjustment_data,
+            } = request;
+            let submission = SignedBidSubmissionV4 {
+                message,
+                execution_payload,
+                blobs_bundle,
+                execution_requests,
+                signature,
+            };
+            Ok(Self::new(submission, Some(adjustment_data)))
+        } else {
+            let submission = SignedBidSubmissionV4::from_ssz_bytes(bytes)?;
+            Ok(Self::new(submission, None))
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Deref)]
+pub struct DenebSubmitBlockRequest {
+    /// Inner bid submission.
+    #[deref]
+    #[serde(flatten)]
+    pub submission: SignedBidSubmissionV3,
+    /// Bid adjustment data if present.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub adjustment_data: Option<BidAdjustmentData>,
+}
+
+impl DenebSubmitBlockRequest {
+    /// Create new Deneb submit block request.
+    pub fn new(
+        submission: SignedBidSubmissionV3,
+        adjustment_data: Option<BidAdjustmentData>,
+    ) -> Self {
+        Self {
+            submission,
+            adjustment_data,
+        }
+    }
+}
+
+impl ssz::Encode for DenebSubmitBlockRequest {
+    fn is_ssz_fixed_len() -> bool {
+        false
+    }
+
+    fn ssz_append(&self, buf: &mut Vec<u8>) {
+        let mut offset = <BidTrace as ssz::Encode>::ssz_fixed_len()
+            + <ExecutionPayloadV3 as ssz::Encode>::ssz_fixed_len()
+            + <BlobsBundleV1 as ssz::Encode>::ssz_fixed_len()
+            + <BlsSignature as ssz::Encode>::ssz_fixed_len();
+        if self.adjustment_data.is_some() {
+            offset += <BidAdjustmentData as ssz::Encode>::ssz_fixed_len();
+        }
+
+        let mut encoder = ssz::SszEncoder::container(buf, offset);
+
+        encoder.append(&self.message);
+        encoder.append(&self.execution_payload);
+        encoder.append(&self.blobs_bundle);
+        encoder.append(&self.signature);
+        if let Some(adjustment) = &self.adjustment_data {
+            encoder.append(&adjustment);
+        }
+
+        encoder.finalize();
+    }
+
+    fn ssz_bytes_len(&self) -> usize {
+        let mut len = <BidTrace as ssz::Encode>::ssz_bytes_len(&self.message)
+            + <ExecutionPayloadV3 as ssz::Encode>::ssz_bytes_len(&self.execution_payload)
+            + <BlobsBundleV1 as ssz::Encode>::ssz_bytes_len(&self.blobs_bundle)
+            + <BlsSignature as ssz::Encode>::ssz_bytes_len(&self.signature);
+        if let Some(adjustment) = &self.adjustment_data {
+            len += <BidAdjustmentData as ssz::Encode>::ssz_bytes_len(adjustment);
+        }
+        len
+    }
+}
+
+impl ssz::Decode for DenebSubmitBlockRequest {
+    fn is_ssz_fixed_len() -> bool {
+        false
+    }
+
+    fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, DecodeError> {
+        #[derive(ssz_derive::Decode)]
+        struct DenebSubmitBlockRequestSszHelper {
+            message: BidTrace,
+            execution_payload: ExecutionPayloadV3,
+            blobs_bundle: BlobsBundleV1,
+            signature: BlsSignature,
+            adjustment_data: BidAdjustmentData,
+        }
+
+        if let Ok(request) = DenebSubmitBlockRequestSszHelper::from_ssz_bytes(bytes) {
+            let DenebSubmitBlockRequestSszHelper {
+                message,
+                execution_payload,
+                blobs_bundle,
+                signature,
+                adjustment_data,
+            } = request;
+            let submission = SignedBidSubmissionV3 {
+                message,
+                execution_payload,
+                blobs_bundle,
+                signature,
+            };
+            Ok(Self::new(submission, Some(adjustment_data)))
+        } else {
+            let submission = SignedBidSubmissionV3::from_ssz_bytes(bytes)?;
+            Ok(Self::new(submission, None))
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Deref)]
+pub struct CapellaSubmitBlockRequest {
+    /// Inner bid submission.
+    #[deref]
+    #[serde(flatten)]
+    pub submission: SignedBidSubmissionV2,
+    /// Bid adjustment data if present.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub adjustment_data: Option<BidAdjustmentData>,
+}
+
+impl CapellaSubmitBlockRequest {
+    /// Create new Capella submit block request.
+    pub fn new(
+        submission: SignedBidSubmissionV2,
+        adjustment_data: Option<BidAdjustmentData>,
+    ) -> Self {
+        Self {
+            submission,
+            adjustment_data,
+        }
+    }
+}
+
+impl ssz::Encode for CapellaSubmitBlockRequest {
+    fn is_ssz_fixed_len() -> bool {
+        false
+    }
+
+    fn ssz_append(&self, buf: &mut Vec<u8>) {
+        let mut offset = <BidTrace as ssz::Encode>::ssz_fixed_len()
+            + <ExecutionPayloadV2 as ssz::Encode>::ssz_fixed_len()
+            + <BlsSignature as ssz::Encode>::ssz_fixed_len();
+        if self.adjustment_data.is_some() {
+            offset += <BidAdjustmentData as ssz::Encode>::ssz_fixed_len();
+        }
+
+        let mut encoder = ssz::SszEncoder::container(buf, offset);
+        encoder.append(&self.message);
+        encoder.append(&self.execution_payload);
+        encoder.append(&self.signature);
+        if let Some(adjustment) = &self.adjustment_data {
+            encoder.append(&adjustment);
+        }
+
+        encoder.finalize();
+    }
+
+    fn ssz_bytes_len(&self) -> usize {
+        let mut len = <BidTrace as ssz::Encode>::ssz_bytes_len(&self.message)
+            + <ExecutionPayloadV2 as ssz::Encode>::ssz_bytes_len(&self.execution_payload)
+            + <BlsSignature as ssz::Encode>::ssz_bytes_len(&self.signature);
+        if let Some(adjustment) = &self.adjustment_data {
+            len += <BidAdjustmentData as ssz::Encode>::ssz_bytes_len(adjustment);
+        }
+        len
+    }
+}
+
+impl ssz::Decode for CapellaSubmitBlockRequest {
+    fn is_ssz_fixed_len() -> bool {
+        false
+    }
+
+    fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, DecodeError> {
+        #[derive(ssz_derive::Decode)]
+        struct CapellaSubmitBlockRequestSszHelper {
+            message: BidTrace,
+            execution_payload: ExecutionPayloadV2,
+            signature: BlsSignature,
+            adjustment_data: BidAdjustmentData,
+        }
+
+        if let Ok(request) = CapellaSubmitBlockRequestSszHelper::from_ssz_bytes(bytes) {
+            let CapellaSubmitBlockRequestSszHelper {
+                message,
+                execution_payload,
+                signature,
+                adjustment_data,
+            } = request;
+            let submission = SignedBidSubmissionV2 {
+                message,
+                execution_payload,
+                signature,
+            };
+            Ok(Self::new(submission, Some(adjustment_data)))
+        } else {
+            let submission = SignedBidSubmissionV2::from_ssz_bytes(bytes)?;
+            Ok(Self::new(submission, None))
+        }
     }
 }
 
@@ -96,13 +400,16 @@ impl serde::Serialize for SubmitBlockRequestNoBlobs<'_> {
                     execution_payload: &'a ExecutionPayloadV3,
                     blobs_bundle: &'a BlobsBundleV1,
                     signature: &'a BlsSignature,
+                    #[serde(skip_serializing_if = "Option::is_none")]
+                    adjustment_data: &'a Option<BidAdjustmentData>,
                 }
 
                 SignedBidSubmissionV3Ref {
-                    message: &v3.0.message,
-                    execution_payload: &v3.0.execution_payload,
+                    message: &v3.message,
+                    execution_payload: &v3.execution_payload,
                     blobs_bundle: &BlobsBundleV1::new([]), // override blobs bundle with empty one
-                    signature: &v3.0.signature,
+                    signature: &v3.signature,
+                    adjustment_data: &v3.adjustment_data,
                 }
                 .serialize(serializer)
             }
@@ -115,14 +422,17 @@ impl serde::Serialize for SubmitBlockRequestNoBlobs<'_> {
                     blobs_bundle: &'a BlobsBundleV1,
                     execution_requests: &'a ExecutionRequestsV4,
                     signature: &'a BlsSignature,
+                    #[serde(skip_serializing_if = "Option::is_none")]
+                    adjustment_data: &'a Option<BidAdjustmentData>,
                 }
 
                 SignedBidSubmissionV4Ref {
-                    message: &v4.0.message,
-                    execution_payload: &v4.0.execution_payload,
+                    message: &v4.message,
+                    execution_payload: &v4.execution_payload,
                     blobs_bundle: &BlobsBundleV1::new([]), // override blobs bundle with empty one
-                    signature: &v4.0.signature,
-                    execution_requests: &v4.0.execution_requests,
+                    signature: &v4.signature,
+                    execution_requests: &v4.execution_requests,
+                    adjustment_data: &v4.adjustment_data,
                 }
                 .serialize(serializer)
             }

--- a/crates/rbuilder/src/mev_boost/submission.rs
+++ b/crates/rbuilder/src/mev_boost/submission.rs
@@ -1,10 +1,13 @@
 use alloy_primitives::U256;
+use alloy_rpc_types_beacon::relay::SignedBidSubmissionV5;
 use alloy_rpc_types_beacon::{
     relay::{BidTrace, SignedBidSubmissionV2, SignedBidSubmissionV3, SignedBidSubmissionV4},
     requests::ExecutionRequestsV4,
     BlsSignature,
 };
-use alloy_rpc_types_engine::{BlobsBundleV1, ExecutionPayloadV2, ExecutionPayloadV3};
+use alloy_rpc_types_engine::{
+    BlobsBundleV1, BlobsBundleV2, ExecutionPayloadV2, ExecutionPayloadV3,
+};
 use derive_more::Deref;
 use serde::{Deserialize, Serialize};
 use ssz::DecodeError;
@@ -16,6 +19,7 @@ use crate::primitives::OrderId;
 #[ssz(enum_behaviour = "transparent")]
 #[serde(untagged)]
 pub enum SubmitBlockRequest {
+    Fulu(FuluSubmitBlockRequest),
     Capella(CapellaSubmitBlockRequest),
     Deneb(DenebSubmitBlockRequest),
     Electra(ElectraSubmitBlockRequest),
@@ -37,8 +41,14 @@ impl SubmitBlockRequest {
         Self::Electra(request)
     }
 
+    #[inline]
+    pub fn fulu(request: FuluSubmitBlockRequest) -> Self {
+        Self::Fulu(request)
+    }
+
     pub fn bid_trace(&self) -> &BidTrace {
         match self {
+            SubmitBlockRequest::Fulu(req) => &req.message,
             SubmitBlockRequest::Capella(req) => &req.message,
             SubmitBlockRequest::Deneb(req) => &req.message,
             SubmitBlockRequest::Electra(req) => &req.message,
@@ -52,6 +62,9 @@ impl ssz::Decode for SubmitBlockRequest {
     }
 
     fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, DecodeError> {
+        if let Ok(result) = FuluSubmitBlockRequest::from_ssz_bytes(bytes) {
+            return Ok(Self::fulu(result));
+        }
         if let Ok(result) = ElectraSubmitBlockRequest::from_ssz_bytes(bytes) {
             return Ok(Self::electra(result));
         }
@@ -61,6 +74,27 @@ impl ssz::Decode for SubmitBlockRequest {
 
         let result = CapellaSubmitBlockRequest::from_ssz_bytes(bytes)?;
         Ok(Self::capella(result))
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Deref)]
+pub struct FuluSubmitBlockRequest {
+    #[deref]
+    #[serde(flatten)]
+    pub submission: SignedBidSubmissionV5,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub adjustment_data: Option<BidAdjustmentData>,
+}
+
+impl FuluSubmitBlockRequest {
+    pub fn new(
+        submission: SignedBidSubmissionV5,
+        adjustment_data: Option<BidAdjustmentData>,
+    ) -> Self {
+        Self {
+            submission,
+            adjustment_data,
+        }
     }
 }
 
@@ -84,6 +118,88 @@ impl ElectraSubmitBlockRequest {
         Self {
             submission,
             adjustment_data,
+        }
+    }
+}
+
+impl ssz::Encode for FuluSubmitBlockRequest {
+    fn is_ssz_fixed_len() -> bool {
+        false
+    }
+
+    fn ssz_append(&self, buf: &mut Vec<u8>) {
+        let mut offset = <BidTrace as ssz::Encode>::ssz_fixed_len()
+            + <ExecutionPayloadV3 as ssz::Encode>::ssz_fixed_len()
+            + <BlobsBundleV2 as ssz::Encode>::ssz_fixed_len()
+            + <ExecutionRequestsV4 as ssz::Encode>::ssz_fixed_len()
+            + <BlsSignature as ssz::Encode>::ssz_fixed_len();
+        if self.adjustment_data.is_some() {
+            offset += <BidAdjustmentData as ssz::Encode>::ssz_fixed_len();
+        }
+
+        let mut encoder = ssz::SszEncoder::container(buf, offset);
+
+        encoder.append(&self.message);
+        encoder.append(&self.execution_payload);
+        encoder.append(&self.blobs_bundle);
+        encoder.append(&self.execution_requests);
+        encoder.append(&self.signature);
+        if let Some(adjustment) = &self.adjustment_data {
+            encoder.append(&adjustment);
+        }
+
+        encoder.finalize();
+    }
+
+    fn ssz_bytes_len(&self) -> usize {
+        let mut len = <BidTrace as ssz::Encode>::ssz_bytes_len(&self.message)
+            + <ExecutionPayloadV3 as ssz::Encode>::ssz_bytes_len(&self.execution_payload)
+            + <BlobsBundleV2 as ssz::Encode>::ssz_bytes_len(&self.blobs_bundle)
+            + <ExecutionRequestsV4 as ssz::Encode>::ssz_bytes_len(&self.execution_requests)
+            + <BlsSignature as ssz::Encode>::ssz_bytes_len(&self.signature);
+        if let Some(adjustment) = &self.adjustment_data {
+            len += <BidAdjustmentData as ssz::Encode>::ssz_bytes_len(adjustment);
+        }
+        len
+    }
+}
+
+impl ssz::Decode for FuluSubmitBlockRequest {
+    fn is_ssz_fixed_len() -> bool {
+        false
+    }
+
+    fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, DecodeError> {
+        #[derive(ssz_derive::Decode)]
+        struct FuluSubmitBlockRequestSszHelper {
+            message: BidTrace,
+            execution_payload: ExecutionPayloadV3,
+            blobs_bundle: BlobsBundleV2,
+            execution_requests: ExecutionRequestsV4,
+            signature: BlsSignature,
+            adjustment_data: BidAdjustmentData,
+        }
+
+        if let Ok(request) = FuluSubmitBlockRequestSszHelper::from_ssz_bytes(bytes) {
+            let FuluSubmitBlockRequestSszHelper {
+                message,
+                execution_payload,
+                blobs_bundle,
+                execution_requests,
+                signature,
+                adjustment_data,
+            } = request;
+            let submission = SignedBidSubmissionV5 {
+                message,
+                execution_payload,
+                blobs_bundle,
+                execution_requests,
+                signature,
+            };
+            Ok(Self::new(submission, Some(adjustment_data)))
+        } else {
+            let submission = SignedBidSubmissionV5::from_ssz_bytes(bytes)?;
+            Ok(Self::new(submission, None))
         }
     }
 }
@@ -433,6 +549,26 @@ impl serde::Serialize for SubmitBlockRequestNoBlobs<'_> {
                     signature: &v4.signature,
                     execution_requests: &v4.execution_requests,
                     adjustment_data: &v4.adjustment_data,
+                }
+                .serialize(serializer)
+            }
+            SubmitBlockRequest::Fulu(v5) => {
+                #[derive(serde::Serialize)]
+                struct SignedBidSubmissionV5Ref<'a> {
+                    message: &'a BidTrace,
+                    #[serde(with = "alloy_rpc_types_beacon::payload::beacon_payload_v3")]
+                    execution_payload: &'a ExecutionPayloadV3,
+                    blobs_bundle: &'a BlobsBundleV2,
+                    execution_requests: &'a ExecutionRequestsV4,
+                    signature: &'a BlsSignature,
+                }
+
+                SignedBidSubmissionV5Ref {
+                    message: &v5.message,
+                    execution_payload: &v5.execution_payload,
+                    blobs_bundle: &BlobsBundleV2::new([]), // override blobs bundle with empty one
+                    signature: &v5.signature,
+                    execution_requests: &v5.execution_requests,
                 }
                 .serialize(serializer)
             }

--- a/crates/rbuilder/src/primitives/mev_boost.rs
+++ b/crates/rbuilder/src/primitives/mev_boost.rs
@@ -2,7 +2,7 @@ use crate::mev_boost::{
     submission::SubmitBlockRequestWithMetadata, RelayClient, RelayError, SubmitBlockErr,
     ValidatorSlotData,
 };
-use alloy_primitives::{utils::parse_ether, U256};
+use alloy_primitives::{utils::parse_ether, Address, U256};
 use governor::{DefaultDirectRateLimiter, Quota, RateLimiter};
 use serde::{Deserialize, Deserializer};
 use std::{env, sync::Arc, time::Duration};
@@ -56,6 +56,8 @@ pub struct RelayConfig {
     /// mode defines the need of submit_config
     #[serde(default)]
     pub mode: RelayMode,
+    /// Bid adjustment fee payer address.
+    pub adjustment_fee_payer: Option<Address>,
     #[serde(flatten)]
     /// Submit specific info.
     /// Used only for Full and Fake mode.

--- a/crates/rbuilder/src/primitives/mod.rs
+++ b/crates/rbuilder/src/primitives/mod.rs
@@ -34,7 +34,6 @@ use sha2::{Digest, Sha256};
 use std::{cmp::Ordering, collections::HashMap, fmt::Display, hash::Hash, str::FromStr, sync::Arc};
 pub use test_data_generator::TestDataGenerator;
 use thiserror::Error;
-use tracing::info;
 use uuid::Uuid;
 
 /// Extra metadata for ShareBundle/Bundle.

--- a/crates/rbuilder/src/primitives/mod.rs
+++ b/crates/rbuilder/src/primitives/mod.rs
@@ -9,6 +9,7 @@ mod test_data_generator;
 
 use crate::building::evm_inspector::UsedStateTrace;
 use alloy_consensus::Transaction as _;
+use alloy_eips::eip7594::BlobTransactionSidecarVariant;
 use alloy_eips::{
     eip2718::{Decodable2718, Eip2718Error, Encodable2718},
     eip4844::{Blob, BlobTransactionSidecar, Bytes48},
@@ -21,10 +22,11 @@ use reth::transaction_pool::{
     BlobStore, BlobStoreError, EthPooledTransaction, Pool, TransactionOrdering, TransactionPool,
     TransactionValidator,
 };
+use reth_ethereum_primitives::PooledTransactionVariant;
 use reth_node_core::primitives::SignedTransaction;
 use reth_primitives::{
     kzg::{BYTES_PER_BLOB, BYTES_PER_COMMITMENT, BYTES_PER_PROOF},
-    PooledTransaction, Recovered, Transaction, TransactionSigned,
+    Recovered, Transaction, TransactionSigned,
 };
 use reth_primitives_traits::SignerRecoverable;
 use serde::{Deserialize, Serialize};
@@ -32,6 +34,7 @@ use sha2::{Digest, Sha256};
 use std::{cmp::Ordering, collections::HashMap, fmt::Display, hash::Hash, str::FromStr, sync::Arc};
 pub use test_data_generator::TestDataGenerator;
 use thiserror::Error;
+use tracing::info;
 use uuid::Uuid;
 
 /// Extra metadata for ShareBundle/Bundle.
@@ -629,7 +632,7 @@ impl ShareBundle {
 pub struct TransactionSignedEcRecoveredWithBlobs {
     tx: Recovered<TransactionSigned>,
     /// Will have a non empty BlobTransactionSidecar if Recovered<TransactionSigned> is 4844
-    pub blobs_sidecar: Arc<BlobTransactionSidecar>,
+    pub blobs_sidecar: Arc<BlobTransactionSidecarVariant>,
 
     #[derivative(PartialEq = "ignore", Hash = "ignore")]
     pub metadata: Metadata,
@@ -701,7 +704,7 @@ impl TransactionSignedEcRecoveredWithBlobs {
     /// or blobs without an eip4844.
     pub fn new(
         tx: Recovered<TransactionSigned>,
-        blob_sidecar: Option<BlobTransactionSidecar>,
+        blob_sidecar: Option<BlobTransactionSidecarVariant>,
         metadata: Option<Metadata>,
     ) -> Result<Self, TxWithBlobsCreateError> {
         // Check for an eip4844 tx passed without blobs
@@ -711,10 +714,26 @@ impl TransactionSignedEcRecoveredWithBlobs {
         } else if blob_sidecar.is_some() && tx.inner().blob_versioned_hashes().is_none() {
             Err(TxWithBlobsCreateError::BlobsMissingEip4844)
         // Groovy!
+        // No blob txs at all
+        } else if let Some(b_sidecar) = blob_sidecar {
+            match b_sidecar {
+                BlobTransactionSidecarVariant::Eip4844(sidecar) => Ok(Self {
+                    tx,
+                    blobs_sidecar: Arc::new(BlobTransactionSidecarVariant::Eip4844(sidecar)),
+                    metadata: metadata.unwrap_or_default(),
+                }),
+                BlobTransactionSidecarVariant::Eip7594(sidecar) => Ok(Self {
+                    tx,
+                    blobs_sidecar: Arc::new(BlobTransactionSidecarVariant::Eip7594(sidecar)),
+                    metadata: metadata.unwrap_or_default(),
+                }),
+            }
         } else {
             Ok(Self {
                 tx,
-                blobs_sidecar: Arc::new(blob_sidecar.unwrap_or_default()),
+                blobs_sidecar: Arc::new(BlobTransactionSidecarVariant::Eip4844(
+                    BlobTransactionSidecar::default(),
+                )),
                 metadata: metadata.unwrap_or_default(),
             })
         }
@@ -744,15 +763,22 @@ impl TransactionSignedEcRecoveredWithBlobs {
     {
         let blob_sidecar = pool
             .get_blob(*tx.inner().hash())?
-            .and_then(|b| b.as_eip4844().cloned());
+            .and_then(|b| Arc::try_unwrap(b).ok());
+        info!(
+            "BHARATH: blob_sidecar is present: {:?}",
+            blob_sidecar.is_some()
+        );
+        // let mut blobs = pool.get_all_blobs(vec![*tx.inner().hash()])?;
+        // let blob_sidecar = blobs.pop().map(|(_, arc)| arc.as_ref().clone());
         Self::new(tx, blob_sidecar, None)
     }
 
     /// Creates a Self with empty blobs sidecar. No consistency check is performed!
     pub fn new_for_testing(tx: Recovered<TransactionSigned>) -> Self {
+        let fake_sidecar = BlobTransactionSidecar::default();
         Self {
             tx,
-            blobs_sidecar: Default::default(),
+            blobs_sidecar: Arc::new(BlobTransactionSidecarVariant::Eip4844(fake_sidecar)),
             metadata: Default::default(),
         }
     }
@@ -801,20 +827,20 @@ impl TransactionSignedEcRecoveredWithBlobs {
         raw_tx: Bytes,
     ) -> Result<TransactionSignedEcRecoveredWithBlobs, TxWithBlobsCreateError> {
         let raw_tx = &mut raw_tx.as_ref();
-        let pooled_tx = PooledTransaction::decode_2718(raw_tx)
+        let pooled_tx = PooledTransactionVariant::decode_2718(raw_tx)
             .map_err(TxWithBlobsCreateError::FailedToDecodeTransaction)?;
         let signer = pooled_tx
             .recover_signer()
             .map_err(|_| TxWithBlobsCreateError::InvalidTransactionSignature)?;
         match pooled_tx {
-            PooledTransaction::Legacy(_)
-            | PooledTransaction::Eip2930(_)
-            | PooledTransaction::Eip1559(_)
-            | PooledTransaction::Eip7702(_) => {
+            PooledTransactionVariant::Legacy(_)
+            | PooledTransactionVariant::Eip2930(_)
+            | PooledTransactionVariant::Eip1559(_)
+            | PooledTransactionVariant::Eip7702(_) => {
                 let tx_signed = TransactionSigned::from(pooled_tx);
                 TransactionSignedEcRecoveredWithBlobs::new_no_blobs(tx_signed.with_signer(signer))
             }
-            PooledTransaction::Eip4844(blob_tx) => {
+            PooledTransactionVariant::Eip4844(blob_tx) => {
                 let (blob_tx, signature, hash) = blob_tx.into_parts();
                 let (blob_tx, sidecar) = blob_tx.into_parts();
                 let tx_signed = TransactionSigned::new_unchecked(
@@ -822,6 +848,7 @@ impl TransactionSignedEcRecoveredWithBlobs {
                     signature,
                     hash,
                 );
+
                 Ok(TransactionSignedEcRecoveredWithBlobs {
                     tx: tx_signed.with_signer(signer),
                     blobs_sidecar: Arc::new(sidecar),
@@ -850,7 +877,7 @@ impl TransactionSignedEcRecoveredWithBlobs {
         }
         Ok(TransactionSignedEcRecoveredWithBlobs {
             tx,
-            blobs_sidecar: Arc::new(fake_sidecar),
+            blobs_sidecar: Arc::new(BlobTransactionSidecarVariant::Eip4844(fake_sidecar)),
             metadata: Metadata::default(),
         })
     }
@@ -1028,7 +1055,14 @@ impl Order {
     pub fn has_blobs(&self) -> bool {
         self.list_txs()
             .iter()
-            .any(|(tx, _)| !tx.blobs_sidecar.blobs.is_empty())
+            .any(|(tx, _)| match tx.blobs_sidecar.as_ref() {
+                BlobTransactionSidecarVariant::Eip4844(eip4844_sidecar) => {
+                    !eip4844_sidecar.blobs.is_empty()
+                }
+                BlobTransactionSidecarVariant::Eip7594(eip7594_sidecar) => {
+                    !eip7594_sidecar.blobs.is_empty()
+                }
+            })
     }
 
     pub fn target_block(&self) -> Option<u64> {

--- a/crates/rbuilder/src/primitives/mod.rs
+++ b/crates/rbuilder/src/primitives/mod.rs
@@ -761,15 +761,8 @@ impl TransactionSignedEcRecoveredWithBlobs {
         T: TransactionOrdering<Transaction = <V as TransactionValidator>::Transaction>,
         S: BlobStore,
     {
-        let blob_sidecar = pool
-            .get_blob(*tx.inner().hash())?
-            .and_then(|b| Arc::try_unwrap(b).ok());
-        info!(
-            "BHARATH: blob_sidecar is present: {:?}",
-            blob_sidecar.is_some()
-        );
-        // let mut blobs = pool.get_all_blobs(vec![*tx.inner().hash()])?;
-        // let blob_sidecar = blobs.pop().map(|(_, arc)| arc.as_ref().clone());
+        let mut blobs = pool.get_all_blobs(vec![*tx.inner().hash()])?;
+        let blob_sidecar = blobs.pop().map(|(_, arc)| arc.as_ref().clone());
         Self::new(tx, blob_sidecar, None)
     }
 

--- a/crates/rbuilder/src/provider/ipc_state_provider.rs
+++ b/crates/rbuilder/src/provider/ipc_state_provider.rs
@@ -18,7 +18,7 @@ use reipc::rpc_provider::RpcProvider;
 use reth_errors::{ProviderError, ProviderResult};
 use reth_primitives::{Account, Bytecode};
 use reth_provider::{
-    errors::any::AnyError, AccountReader, BlockHashReader, HashedPostStateProvider,
+    errors::any::AnyError, AccountReader, BlockHashReader, BytecodeReader, HashedPostStateProvider,
     StateProofProvider, StateProvider, StateProviderBox, StateRootProvider, StorageRootProvider,
 };
 use reth_trie::{
@@ -242,26 +242,7 @@ impl IpcStateProvider {
     }
 }
 
-impl StateProvider for IpcStateProvider {
-    /// Get storage of given account
-    fn storage(
-        &self,
-        account: Address,
-        storage_key: StorageKey,
-    ) -> ProviderResult<Option<StorageValue>> {
-        if let Some(storage) = self.storage_cache.get(&(account, storage_key)) {
-            return Ok(*storage);
-        }
-
-        let key: U256 = storage_key.into();
-        let storage = rpc_call(&self.ipc_provider, "eth_getStorageAt", (account, key))?;
-        self.storage_cache.insert((account, storage_key), storage);
-
-        Ok(storage)
-    }
-
-    /// Get account code by its hash
-    /// IMPORTANT: Assumes remote provider (node) has RPC call:"rbuilder_getCodeByHash"
+impl BytecodeReader for IpcStateProvider {
     fn bytecode_by_hash(&self, code_hash: &B256) -> ProviderResult<Option<Bytecode>> {
         let empty_hash = code_hash.is_zero() || *code_hash == KECCAK_EMPTY;
         if empty_hash {
@@ -284,6 +265,25 @@ impl StateProvider for IpcStateProvider {
         });
 
         Ok(bytecode)
+    }
+}
+
+impl StateProvider for IpcStateProvider {
+    /// Get storage of given account
+    fn storage(
+        &self,
+        account: Address,
+        storage_key: StorageKey,
+    ) -> ProviderResult<Option<StorageValue>> {
+        if let Some(storage) = self.storage_cache.get(&(account, storage_key)) {
+            return Ok(*storage);
+        }
+
+        let key: U256 = storage_key.into();
+        let storage = rpc_call(&self.ipc_provider, "eth_getStorageAt", (account, key))?;
+        self.storage_cache.insert((account, storage_key), storage);
+
+        Ok(storage)
     }
 }
 

--- a/crates/test-relay/src/relay.rs
+++ b/crates/test-relay/src/relay.rs
@@ -20,15 +20,20 @@ use rbuilder::{
     primitives::mev_boost::MevBoostRelaySlotInfoProvider,
 };
 use serde::{Deserialize, Serialize};
-use std::time::Instant;
-use std::{collections::hash_map::Entry, sync::Arc, time::Duration};
-use std::{io::Read, net::SocketAddr};
+use ssz::Decode as _;
+use std::{
+    collections::hash_map::Entry,
+    io::Read,
+    net::SocketAddr,
+    sync::Arc,
+    time::{Duration, Instant},
+};
 use time::OffsetDateTime;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
-use warp::body;
 use warp::{
+    body,
     http::status::StatusCode,
     query,
     reply::{self, Reply},

--- a/crates/test-relay/src/validation_api_client.rs
+++ b/crates/test-relay/src/validation_api_client.rs
@@ -69,6 +69,7 @@ impl ValidationAPIClient {
         }
 
         let method = match req {
+            SubmitBlockRequest::Fulu(_) => "flashbots_validateBuilderSubmissionV5",
             SubmitBlockRequest::Capella(_) => "flashbots_validateBuilderSubmissionV2",
             SubmitBlockRequest::Deneb(_) => "flashbots_validateBuilderSubmissionV3",
             SubmitBlockRequest::Electra(_) => "flashbots_validateBuilderSubmissionV4",


### PR DESCRIPTION
Things to consider in rbuilder:

**Breaking changes:**
1. **alloy/nybbles:** https://github.com/alloy-rs/nybbles/pull/17 updates the internal representation of `Nibble` from a `SmallVec<[u8; 64]>` to a `U256`. This breaks code in the merkle eth sparse tree as the code indexes a lot into the `SmallVec` representation
2. **alloy/eips**: https://github.com/alloy-rs/alloy/blob/fusaka/devnet2/crates/eips/src/eip7594/sidecar.rs#L25 we need to use `BlobTransactionSidecarVariant` enum which contains PeerDas type blob sidecars too. The only different b/w EIP-7954 sidecars from EIP-4844 sidecars is EIP-7954 sidecars use `cell_proofs` instead of `proofs`. rbuilder just uses `BlobTransactionSidecar` which breaks with the fulu hard fork.
3. **revm/context**: https://github.com/bluealloy/revm/commit/c70bb9a8c3d2d1fa3f24bcba744d7825d80a7637 this commit updates the `BlockNumber` and `Timestamp` to use `U256` instead of `u64`. There are inconsistencies in code where u64 is used for block number which fails to build as a result.
4. **revm/state**: changes made for EIP-7907: https://github.com/bluealloy/revm/commit/d8c4567f34e57d7f19804fbe6bc8adf70ee30ace introduces the `CodeSize` field to the `AccountInfo` . It was previously an `Option` but the mentioned commit makes it a mandatory field. 
5. **alloy/evm**: The `Database` trait in the alloy/evm repo now implements `std::fmt::Debug` implemented by https://github.com/alloy-rs/evm/commit/3d6a01b3594f66aaf60bcc93b7b2e3cd552ec7a8. This broke code since a dependency was using the updated `Database` trait from alloy/evm. Using the `Database` trait from alloy/evm seems to have fixed this. 
6. **revm/inspector**: It appears that the `step` method has been removed from the `access_list_inspector`. We need to update the `revm-inspectors` crate.
7. The method `bytecode_by_hash` is now defined in trait `BytecodeReader` rather than in the `StateProvider`

**Notes**
1. We need to send `BlobsBundleV2` to the relay. https://github.com/alloy-rs/alloy/blob/fusaka/devnet2/crates/rpc-types-engine/src/payload.rs#L906
2. We need to send a `SignedBidSubmissionV5` to the relay overall: https://github.com/alloy-rs/alloy/blob/main/crates/rpc-types-beacon/src/relay.rs#L183